### PR TITLE
build(.releaserc): add .releaserc to trigger releases from more commit types

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,37 @@
+<!-- What changes are being made? Please link the issue being addressed. -->
+
+**What**: Closes #
+
+<!-- Are there any upstream issues or separate issues you need to reference? -->
+
+**Additional issues**:
+
+<!--
+  NOTE: Please format your PR title according to our semantic-release configuration.
+  Your PR title (and resulting squashed commit message) must follow this syntax:
+
+      type(scope): description
+
+  The scope can be a filename or other short string explaining what part of the code you are touching. For example:
+
+      feat(MyComponent): Added someProp for blah feature
+
+  Valid types for a minor release (*.X.* version bump):
+      feat - A new feature
+
+  Valid types for a patch release (*.*.X version bump):
+      fix - A bug fix
+      docs - Documentation only changes
+      style - Changes that do not affect the meaning of the code
+      refactor - A code change that neither fixes a bug nor adds a feature
+      perf - A code change that improves performance
+      build - Changes that affect the build system or external dependencies
+      revert - Reverts a previous commit
+      test - Adding missing tests or correcting existing tests
+
+  Valid types that do not trigger a release, but will end up in the next release notes:
+      ci - Changes to our CI configuration files and scripts
+      chore - Other changes that don't modify src or test files
+
+  If your PR contains any breaking changes such as removing or renaming props, put the words BREAKING CHANGES somewhere in your PR description. This will trigger a major version bump (X.*.*).
+-->

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,62 @@
+{
+  "branches": [
+    "master"
+  ],
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "angular",
+        "releaseRules": [
+          {
+            "breaking": true,
+            "release": "major"
+          },
+          {
+            "type": "feat",
+            "release": "minor"
+          },
+          {
+            "type": "fix",
+            "release": "patch"
+          },
+          {
+            "type": "docs",
+            "release": "patch"
+          },
+          {
+            "type": "style",
+            "release": "patch"
+          },
+          {
+            "type": "refactor",
+            "release": "patch"
+          },
+          {
+            "type": "perf",
+            "release": "patch"
+          },
+          {
+            "type": "build",
+            "release": "patch"
+          },
+          {
+            "revert": true,
+            "release": "patch"
+          },
+          {
+            "type": "test",
+            "release": "patch"
+          }
+        ],
+        "parserOpts": {
+          "noteKeywords": [
+            "BREAKING CHANGE",
+            "BREAKING CHANGES"
+          ]
+        }
+      }
+    ],
+    "@semantic-release/release-notes-generator"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ yarn storybook:export
 
 ## Triggering an npm release
 
-This project uses [semantic-release](https://github.com/semantic-release/semantic-release) via GitHub Actions to automate its npm releases. When a PR is merged to master, it is checked for specific key words in the commit message to decide whether a release needs to be made, and whether it will be a minor or major version bump.
+This project uses [semantic-release](https://github.com/semantic-release/semantic-release) via GitHub Actions to automate its npm releases. When a commit is pushed to master, it is checked for specific key words in the commit message to decide whether a release needs to be made, and whether it will be a minor or major version bump. Your commit message will also be added and categorized in the release notes.
 
 To assist in formatting commit messages correctly for this purpose, the repo is set up for use with [Commitizen](http://commitizen.github.io/cz-cli/), which provides a CLI for guided commit messages.
 
@@ -115,7 +115,7 @@ First, `git add` any changes you want to commit, then:
 yarn commit
 ```
 
-Follow the prompts based on the scope of your commit. When your commit is merged to master, an automatic release will be triggered and a message will be posted to your PR when it is complete.
+Follow the prompts based on the scope of your commit. **Note: This will generate a message for an individual commit, but since we use squash-and-merge, what matters is your PR title.** If your PR contains multiple commits, please make sure the PR title itself matches the expected format. [See our PR template for more details](https://github.com/konveyor/lib-ui/blob/master/.github/pull_request_template.md).
 
 ## File Structure
 


### PR DESCRIPTION
Also adds a pull request template that will explain how to trigger releases when opening a pull request.