### PR TITLE
fix(statusicon): add support for ReactNode labels instead of strings

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,31 +7,30 @@
 **Additional issues**:
 
 <!--
-  NOTE: Please format your PR title according to our semantic-release configuration.
-  Your PR title (and resulting squashed commit message) must follow this syntax:
+    NOTE: Please format your PR title (or your commit message, if there is only one commit) according to our semantic-release configuration. Your PR title (and resulting squashed commit message) must follow this syntax:
 
-      type(scope): description
+        type(scope): description
 
-  The scope can be a filename or other short string explaining what part of the code you are touching. For example:
+    The scope can be a filename or other short string explaining what part of the code you are touching. For example:
 
-      feat(MyComponent): Added someProp for blah feature
+        feat(MyComponent): Added someProp for blah feature
 
-  Valid types for a minor release (*.X.* version bump):
-      feat - A new feature
+    Valid types for a minor release (*.X.* version bump):
+        feat - A new feature
 
-  Valid types for a patch release (*.*.X version bump):
-      fix - A bug fix
-      docs - Documentation only changes
-      style - Changes that do not affect the meaning of the code
-      refactor - A code change that neither fixes a bug nor adds a feature
-      perf - A code change that improves performance
-      build - Changes that affect the build system or external dependencies
-      revert - Reverts a previous commit
-      test - Adding missing tests or correcting existing tests
+    Valid types for a patch release (*.*.X version bump):
+        fix - A bug fix
+        docs - Documentation only changes
+        style - Changes that do not affect the meaning of the code
+        refactor - A code change that neither fixes a bug nor adds a feature
+        perf - A code change that improves performance
+        build - Changes that affect the build system or external dependencies
+        revert - Reverts a previous commit
+        test - Adding missing tests or correcting existing tests
 
-  Valid types that do not trigger a release, but will end up in the next release notes:
-      ci - Changes to our CI configuration files and scripts
-      chore - Other changes that don't modify src or test files
+    Valid types that do not trigger a release, but will end up in the next release notes:
+        ci - Changes to our CI configuration files and scripts
+        chore - Other changes that don't modify src or test files
 
-  If your PR contains any breaking changes such as removing or renaming props, put the words BREAKING CHANGES somewhere in your PR description. This will trigger a major version bump (X.*.*).
+    If your PR contains any breaking changes such as removing or renaming props, put the words BREAKING CHANGES somewhere in your PR description. This will trigger a major version bump (X.*.*).
 -->

--- a/src/components/StatusIcon/StatusIcon.tsx
+++ b/src/components/StatusIcon/StatusIcon.tsx
@@ -20,7 +20,7 @@ export enum StatusType {
 
 export interface IStatusIconProps {
   status: StatusType;
-  label?: string;
+  label?: React.ReactNode;
   isDisabled?: boolean;
   className?: string;
 }
@@ -58,7 +58,11 @@ export const StatusIcon: React.FunctionComponent<IStatusIconProps> = ({
   }
   if (label) {
     return (
-      <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+      <Flex
+        spaceItems={{ default: 'spaceItemsSm' }}
+        alignItems={{ default: 'alignItemsCenter' }}
+        className={className}
+      >
         <FlexItem>{icon}</FlexItem>
         <FlexItem>{label}</FlexItem>
       </Flex>


### PR DESCRIPTION
Already found an issue when trying to use StatusIcon in mig-ui. Also snuck in a tweak to the PR template now that I can see it in action.