### PR TITLE
feat(useselectionstate): add useSelectionState hook, stories and test stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,15 +119,18 @@ Follow the prompts based on the scope of your commit. **Note: This will generate
 
 ## File Structure
 
-Components live in `src/MyComponent/` directories, which should each contain:
+Components live in `src/components/MyComponent/` directories, which should each contain:
 
 - `MyComponent.tsx` - component source and type interfaces (types can be their own file if they are verbose enough)
 - `MyComponent.scss` - any custom styles not covered by PatternFly, we should avoid these when possible
-- `MyComponent.stories.mdx` - define your [Storybook stories](https://storybook.js.org/docs/react/get-started/whats-a-story) (examples and docs) for your component. We are using the [MDX story format](https://storybook.js.org/docs/react/writing-docs/mdx).
+- `MyComponent.stories.mdx` - define your [Storybook stories](https://storybook.js.org/docs/react/get-started/whats-a-story) (examples and docs) for your component. We are using the [MDX story format](https://storybook.js.org/docs/react/writing-docs/mdx). The `title` prop of your story's `<Meta>` defines where it appears in the Storybook nav.
+- Optional: `MyComponent.stories.tsx` - if you need to use TypeScript in the body of your MDX stories, you'll need to define them in a TypeScript file and import them into your MDX file. See existing stories for examples.
 - `MyComponent.test.tsx` - unit tests using [jest](https://jestjs.io/) and [react-testing-library](https://testing-library.com/docs/react-testing-library/intro)
 - `index.ts` - define your exports for the component directory
 
-When you add a new component, be sure to also export it at the top level (`src/index.ts`)
+When you add a new component, be sure to also export it at the top level (`src/index.ts`).
+
+Hooks follow the same structure, but they live under `src/hooks/`.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@babel/core": "^7.11.1",
     "@patternfly/react-core": "^4.40.4",
+    "@patternfly/react-table": "^4.16.7",
     "@patternfly/react-tokens": "^4.9.4",
     "@rollup/plugin-commonjs": "^14.0.0",
     "@rollup/plugin-node-resolve": "^8.4.0",

--- a/src/hooks/useSelectionState/index.ts
+++ b/src/hooks/useSelectionState/index.ts
@@ -1,0 +1,1 @@
+export * from './useSelectionState';

--- a/src/hooks/useSelectionState/useSelectionState.stories.mdx
+++ b/src/hooks/useSelectionState/useSelectionState.stories.mdx
@@ -1,0 +1,64 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
+import { useSelectionState } from './useSelectionState';
+import { Checkboxes, ExpandableTable } from './useSelectionState.stories.tsx';
+import GithubLink from '../../../.storybook/helpers/GithubLink';
+
+<Meta title="Hooks/useSelectionState" component={useSelectionState} />
+
+# useSelectionState
+
+A custom hook for managing a subset of an array which represents the user's current selection of items in that array.
+Can be used for a set of selected checkboxes, a set of expanded rows in an expandable table, and more.
+
+Supports passing a TypeScript type for the array items using [generics](https://www.typescriptlang.org/docs/handbook/generics.html).
+
+<!-- Not sure if there is a way to pull in this signature from the source automatically, that'd be better -->
+
+```ts
+// Syntax:
+const selectionState = useSelectionState<T>(args: ISelectionStateArgs<T>);
+
+// Arguments:
+interface ISelectionStateArgs<T> {
+  items: T[];
+  initialSelected?: T[]; // Defaults to []
+  isEqual?: (a: T, b: T) => boolean; // Defaults to (a, b) => a === b
+}
+
+// Return value:
+interface ISelectionState<T> {
+  selectedItems: T[];
+  isItemSelected: (item: T) => boolean;
+  toggleItemSelected: (item: T, isSelecting?: boolean) => void;
+  areAllSelected: boolean;
+  selectAll: (isSelecting?: boolean) => void;
+  setSelectedItems: (items: T[]) => void;
+}
+```
+
+The hook keeps references to your actual item objects instead of an id or key in its state, so that the
+resulting `selectedItems` array contains all relevant context for use in e.g. form submission.
+It returns state and functions you can use to inspect and update the selections.
+
+In your component, you can use `isItemSelected(item)` when rendering the selected state of an item.
+`isItemSelected` uses the hook's `isEqual` argument to compare the given item with the selected items.
+By default, this uses referential equality (`===`), which works great if you're working with immutable data.
+
+However, **if your item objects can change between renders, you need to specify an alternate implementation of the `isEqual` argument.**
+For example, if your items have `id` properties, you can use `isEqual: (a, b) => a.id === b.id`.
+
+## Examples
+
+### Checkboxes
+
+<Canvas>
+  <Story story={Checkboxes} />
+</Canvas>
+
+### Expandable table
+
+<Canvas>
+  <Story story={ExpandableTable} />
+</Canvas>
+
+<GithubLink path="src/hooks/useSelectionState/useSelectionState.ts" />

--- a/src/hooks/useSelectionState/useSelectionState.stories.tsx
+++ b/src/hooks/useSelectionState/useSelectionState.stories.tsx
@@ -1,0 +1,108 @@
+import * as React from 'react';
+import { Checkbox } from '@patternfly/react-core';
+import { Table, TableHeader, TableBody, ICell, IRow } from '@patternfly/react-table';
+import { useSelectionState } from './useSelectionState';
+
+export const Checkboxes: React.FunctionComponent = () => {
+  // import { Checkbox } from '@patternfly/react-core';
+
+  interface IFruit {
+    name: string;
+    // Anything else, this can come straight from API data
+  }
+
+  const fruits: IFruit[] = [{ name: 'Apple' }, { name: 'Orange' }, { name: 'Banana' }];
+
+  const {
+    selectedItems,
+    isItemSelected,
+    toggleItemSelected,
+    areAllSelected,
+    selectAll,
+  } = useSelectionState<IFruit>({
+    items: fruits,
+    isEqual: (a, b) => a.name === b.name,
+  });
+
+  return (
+    <div>
+      <Checkbox
+        id="select-all"
+        label="Select all"
+        isChecked={areAllSelected}
+        onChange={(checked) => selectAll(checked)}
+      />
+      <br />
+      {fruits.map((fruit) => (
+        <Checkbox
+          key={fruit.name}
+          id={`${fruit.name}-checkbox`}
+          label={fruit.name}
+          isChecked={isItemSelected(fruit)}
+          onChange={() => toggleItemSelected(fruit)}
+        />
+      ))}
+      {selectedItems.length > 0 ? (
+        <>
+          <br />
+          <p>Do something with these! {selectedItems.map((fruit) => fruit.name).join(', ')}</p>
+        </>
+      ) : null}
+    </div>
+  );
+};
+
+export const ExpandableTable: React.FunctionComponent = () => {
+  // import { Table, TableHeader, TableBody, ICell, IRow } from '@patternfly/react-table';
+
+  interface IFruit {
+    name: string;
+    price: string;
+    description: string;
+  }
+
+  const fruits: IFruit[] = [
+    { name: 'Apple', price: '$0.83', description: 'Red delicious!' },
+    { name: 'Orange', price: '$0.74', description: 'Fresh and juicy!' },
+    { name: 'Banana', price: '$0.45', description: 'On sale this week!' },
+  ];
+
+  const {
+    isItemSelected: isItemExpanded,
+    toggleItemSelected: toggleItemExpanded,
+  } = useSelectionState<IFruit>({
+    items: fruits,
+    isEqual: (a, b) => a.name === b.name,
+  });
+
+  const columns: ICell[] = [{ title: 'Name' }, { title: 'Price' }];
+  const rows: IRow[] = [];
+  fruits.forEach((fruit) => {
+    const isExpanded = isItemExpanded(fruit);
+    rows.push({
+      meta: { fruit },
+      isOpen: isExpanded,
+      cells: [fruit.name, fruit.price],
+    });
+    if (isExpanded) {
+      rows.push({
+        parent: rows.length - 1,
+        fullWidth: true,
+        cells: [fruit.description],
+      });
+    }
+  });
+
+  return (
+    <Table
+      variant="compact"
+      aria-label="Fruits table"
+      onCollapse={(_event, _rowIndex, _isOpen, rowData) => toggleItemExpanded(rowData.meta.fruit)}
+      cells={columns}
+      rows={rows}
+    >
+      <TableHeader />
+      <TableBody />
+    </Table>
+  );
+};

--- a/src/hooks/useSelectionState/useSelectionState.test.ts
+++ b/src/hooks/useSelectionState/useSelectionState.test.ts
@@ -1,0 +1,21 @@
+// import { useSelectionState } from './useSelectionState';
+
+// TODO add tests here
+
+describe('useSelectionState', () => {
+  it.skip('updates state correctly when toggling an item', () => {
+    // TODO
+  });
+  it.skip('updates state correctly when selecting/deselecting all', () => {
+    // TODO
+  });
+  it.skip('preserves the original order of items when selecting out of order', () => {
+    // TODO
+  });
+  it.skip('handles initialSelected properly', () => {
+    // TODO
+  });
+  it.skip('handles a custom isEqual arg properly', () => {
+    // TODO
+  });
+});

--- a/src/hooks/useSelectionState/useSelectionState.ts
+++ b/src/hooks/useSelectionState/useSelectionState.ts
@@ -1,0 +1,54 @@
+import * as React from 'react';
+
+export interface ISelectionStateArgs<T> {
+  items: T[];
+  initialSelected?: T[];
+  isEqual?: (a: T, b: T) => boolean;
+}
+
+export interface ISelectionState<T> {
+  selectedItems: T[];
+  isItemSelected: (item: T) => boolean;
+  toggleItemSelected: (item: T, isSelecting?: boolean) => void;
+  areAllSelected: boolean;
+  selectAll: (isSelecting?: boolean) => void;
+  setSelectedItems: (items: T[]) => void;
+}
+
+export const useSelectionState = <T>({
+  items,
+  initialSelected = [],
+  isEqual = (a, b) => a === b,
+}: ISelectionStateArgs<T>): ISelectionState<T> => {
+  const [selectedItems, setSelectedItems] = React.useState<T[]>(initialSelected);
+
+  const isItemSelected = (item: T) => selectedItems.some((i) => isEqual(item, i));
+
+  const toggleItemSelected = (item: T, isSelecting = !isItemSelected(item)) => {
+    if (isSelecting) {
+      setSelectedItems([...selectedItems, item]);
+    } else {
+      setSelectedItems(selectedItems.filter((i) => !isEqual(i, item)));
+    }
+  };
+
+  const selectAll = (isSelecting = true) => setSelectedItems(isSelecting ? items : []);
+  const areAllSelected = selectedItems.length === items.length;
+
+  // Preserve original order of items
+  let selectedItemsInOrder: T[] = [];
+  if (areAllSelected) {
+    selectedItemsInOrder = items;
+  } else if (selectedItems.length > 0) {
+    selectedItemsInOrder = items.filter(isItemSelected);
+  }
+
+  return {
+    selectedItems: selectedItemsInOrder,
+    isItemSelected,
+    toggleItemSelected,
+    areAllSelected,
+    selectAll,
+    setSelectedItems,
+  };
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from './components/StatusIcon';
+export * from './hooks/useSelectionState';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1859,6 +1859,11 @@
   dependencies:
     "@types/node" ">= 8"
 
+"@patternfly/patternfly@4.35.2":
+  version "4.35.2"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.35.2.tgz#a8d7cf49b5da714e175efd0faabef295697da8d0"
+  integrity sha512-gOebIesqY28/ngVz0k/k0szca247002x+x+GBfCNgbnOXoiEfqYViI5C7YuHB8iNVuvf/YwBdfj65k/h6FMB3w==
+
 "@patternfly/react-core@^4.40.4":
   version "4.40.4"
   resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.40.4.tgz#e4409f89327e2fcdcd07a08833c0149e6f2f6966"
@@ -1872,20 +1877,61 @@
     tippy.js "5.1.2"
     tslib "^1.11.1"
 
+"@patternfly/react-core@^4.47.0":
+  version "4.47.0"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.47.0.tgz#310876ff2567b45319ba2f7de6ae189095fde9ad"
+  integrity sha512-Qw6pBzBf4p3juOCeSRwHyYbTgNW8LG8PZc/xf7BonBrtWwIrpuo7PpqfSEmQDoZ5NjqGmaQpqFZ9vtsTU/Yvow==
+  dependencies:
+    "@patternfly/react-icons" "^4.7.4"
+    "@patternfly/react-styles" "^4.7.3"
+    "@patternfly/react-tokens" "^4.9.6"
+    focus-trap "4.0.2"
+    react-dropzone "9.0.0"
+    tippy.js "5.1.2"
+    tslib "^1.11.1"
+
 "@patternfly/react-icons@^4.7.2":
   version "4.7.2"
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.7.2.tgz#f4ad252cb5682bd95da474ce9ce6ddf7fb3a1ac1"
   integrity sha512-r1yCVHxUtRSblo8VwfaUM0d49z4eToZXAI0VzOnfKPRgSmGZrn6l8soQgDDtyQsSDr534Qvm55y/qLrlR9JCnw==
+
+"@patternfly/react-icons@^4.7.4":
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.7.4.tgz#f18d7ea8011b477fd1db80113572680c67204592"
+  integrity sha512-j+N582TJ1MBZWePwP5wFc+qIlGSPkAtnv+pupiAewTWeJnd8TzogoUzlqUHnJNNn8x2Ktrsa561g23HYIIkRWg==
 
 "@patternfly/react-styles@^4.7.2":
   version "4.7.2"
   resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.7.2.tgz#6671a243401ef55adddcb0e0922f5f5f4eea840e"
   integrity sha512-r3zyrt1mXcqdXaEq+otl1cGsN0Ou1k8uIJSY+4EGe2A5jLGbX3vBTwUrpPKLB6tUdNL+mZriFf+3oKhWbVZDkw==
 
+"@patternfly/react-styles@^4.7.3":
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.7.3.tgz#b512d44e1654d952e1f8200ed94d14b91cbad3d0"
+  integrity sha512-p59J4ceql/nUeS6CqwiceBDhFZ1UzBC0BlqxmaBpjSdcxZhRlYoOeCfFZJpJzFDmNTKCxFrvWihXBHgx82h2Hg==
+
+"@patternfly/react-table@^4.16.7":
+  version "4.16.7"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-4.16.7.tgz#4c3785de940ee5dc9b43cbedf3b6943e1fb9ac9f"
+  integrity sha512-NgmwMSiZ3KP+4HKH/vMpQQ8lrKCHxQSp2c8DeZwYZFuaVniyOyTxP9meXOEHIUmXhvB+S/6UXCoPnB6W6/S6Og==
+  dependencies:
+    "@patternfly/patternfly" "4.35.2"
+    "@patternfly/react-core" "^4.47.0"
+    "@patternfly/react-icons" "^4.7.4"
+    "@patternfly/react-styles" "^4.7.3"
+    "@patternfly/react-tokens" "^4.9.6"
+    lodash "^4.17.19"
+    tslib "^1.11.1"
+
 "@patternfly/react-tokens@^4.9.4":
   version "4.9.4"
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.9.4.tgz#71ea3c33045fb29bcc8d98f2c0f07bfcdc89a12c"
   integrity sha512-AJpcAvzWXvfThT2mx24rV7OJSHvZnIsOP1bVrXiubpFAJhi/Suq+LGe/lTPUnuSXaflwyDBRZDXWWmJb4yaWqg==
+
+"@patternfly/react-tokens@^4.9.6":
+  version "4.9.6"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.9.6.tgz#4df2c49173184a0c16c754329311d87c8c2a6778"
+  integrity sha512-HxJ49yDar5+PEVQGvXd3WKuDTXhm5opYg7wU9lNlh72+8TPXw1gIxTO8WIfPhjWxwEwwukVb2Cd/yTSYK81rdg==
 
 "@reach/router@^1.3.3":
   version "1.3.4"


### PR DESCRIPTION
Adding one of the custom hooks I introduced in virt-ui, so I can mess with the usage of hooks in Storybook stories.

Turns out you can't use TypeScript directly in an MDX file, but Storybook supports importing the body of a story from another file.

I'll leave the rest of #12 for another day so I can get back to working on virt-ui.