### PR TITLE
feat(useselectionstate): add support for externally lifted state

### DIFF
--- a/src/hooks/useSelectionState/useSelectionState.stories.mdx
+++ b/src/hooks/useSelectionState/useSelectionState.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
 import { useSelectionState } from './useSelectionState';
-import { Checkboxes, ExpandableTable } from './useSelectionState.stories.tsx';
+import { Checkboxes, ExpandableTable, ExternalState } from './useSelectionState.stories.tsx';
 import GithubLink from '../../../.storybook/helpers/GithubLink';
 
 <Meta title="Hooks/useSelectionState" component={useSelectionState} />
@@ -23,6 +23,7 @@ interface ISelectionStateArgs<T> {
   items: T[];
   initialSelected?: T[]; // Defaults to []
   isEqual?: (a: T, b: T) => boolean; // Defaults to (a, b) => a === b
+  externalState?: [T[], React.Dispatch<React.SetStateAction<T[]>>];
 }
 
 // Return value:
@@ -40,12 +41,20 @@ The hook keeps references to your actual item objects instead of an id or key in
 resulting `selectedItems` array contains all relevant context for use in e.g. form submission.
 It returns state and functions you can use to inspect and update the selections.
 
+## Rendering the selected state
+
 In your component, you can use `isItemSelected(item)` when rendering the selected state of an item.
 `isItemSelected` uses the hook's `isEqual` argument to compare the given item with the selected items.
 By default, this uses referential equality (`===`), which works great if you're working with immutable data.
 
 However, **if your item objects can change between renders, you need to specify an alternate implementation of the `isEqual` argument.**
 For example, if your items have `id` properties, you can use `isEqual: (a, b) => a.id === b.id`.
+
+## Lifting state to an external scope
+
+If necessary, you can pass the optional `externalState` prop in order to manage the actual selections array itself from outside the hook.
+This may be useful if you need to manage the state as part of a centralized form, but you still want the logic from these methods.
+The type of `externalState` is the same as the array returned from `React.useState` (a tuple of `value` and `setValue`.)
 
 ## Examples
 
@@ -59,6 +68,12 @@ For example, if your items have `id` properties, you can use `isEqual: (a, b) =>
 
 <Canvas>
   <Story story={ExpandableTable} />
+</Canvas>
+
+### Checkboxes with external state
+
+<Canvas>
+  <Story story={ExternalState} />
 </Canvas>
 
 <GithubLink path="src/hooks/useSelectionState/useSelectionState.ts" />

--- a/src/hooks/useSelectionState/useSelectionState.stories.tsx
+++ b/src/hooks/useSelectionState/useSelectionState.stories.tsx
@@ -106,3 +106,52 @@ export const ExpandableTable: React.FunctionComponent = () => {
     </Table>
   );
 };
+
+export const ExternalState: React.FunctionComponent = () => {
+  // import { Checkbox } from '@patternfly/react-core';
+
+  interface IFruit {
+    name: string;
+    // Anything else, this can come straight from API data
+  }
+
+  // Somewhere else in your app, perhaps:
+  const [selectedFruits, setSelectedFruits] = React.useState<IFruit[]>([]);
+
+  const fruits: IFruit[] = [{ name: 'Apple' }, { name: 'Orange' }, { name: 'Banana' }];
+
+  const { isItemSelected, toggleItemSelected, areAllSelected, selectAll } = useSelectionState<
+    IFruit
+  >({
+    items: fruits,
+    isEqual: (a, b) => a.name === b.name,
+    externalState: [selectedFruits, setSelectedFruits],
+  });
+
+  return (
+    <div>
+      <Checkbox
+        id="select-all"
+        label="Select all"
+        isChecked={areAllSelected}
+        onChange={(checked) => selectAll(checked)}
+      />
+      <br />
+      {fruits.map((fruit) => (
+        <Checkbox
+          key={fruit.name}
+          id={`${fruit.name}-checkbox`}
+          label={fruit.name}
+          isChecked={isItemSelected(fruit)}
+          onChange={() => toggleItemSelected(fruit)}
+        />
+      ))}
+      {selectedFruits.length > 0 ? (
+        <>
+          <br />
+          <p>Do something with these! {selectedFruits.map((fruit) => fruit.name).join(', ')}</p>
+        </>
+      ) : null}
+    </div>
+  );
+};

--- a/src/hooks/useSelectionState/useSelectionState.stories.tsx
+++ b/src/hooks/useSelectionState/useSelectionState.stories.tsx
@@ -4,11 +4,8 @@ import { Table, TableHeader, TableBody, ICell, IRow } from '@patternfly/react-ta
 import { useSelectionState } from './useSelectionState';
 
 export const Checkboxes: React.FunctionComponent = () => {
-  // import { Checkbox } from '@patternfly/react-core';
-
   interface IFruit {
     name: string;
-    // Anything else, this can come straight from API data
   }
 
   const fruits: IFruit[] = [{ name: 'Apple' }, { name: 'Orange' }, { name: 'Banana' }];
@@ -53,8 +50,6 @@ export const Checkboxes: React.FunctionComponent = () => {
 };
 
 export const ExpandableTable: React.FunctionComponent = () => {
-  // import { Table, TableHeader, TableBody, ICell, IRow } from '@patternfly/react-table';
-
   interface IFruit {
     name: string;
     price: string;
@@ -108,21 +103,21 @@ export const ExpandableTable: React.FunctionComponent = () => {
 };
 
 export const ExternalState: React.FunctionComponent = () => {
-  // import { Checkbox } from '@patternfly/react-core';
-
   interface IFruit {
     name: string;
-    // Anything else, this can come straight from API data
   }
 
-  // Somewhere else in your app, perhaps:
   const [selectedFruits, setSelectedFruits] = React.useState<IFruit[]>([]);
 
   const fruits: IFruit[] = [{ name: 'Apple' }, { name: 'Orange' }, { name: 'Banana' }];
 
-  const { isItemSelected, toggleItemSelected, areAllSelected, selectAll } = useSelectionState<
-    IFruit
-  >({
+  const {
+    selectedItems,
+    isItemSelected,
+    toggleItemSelected,
+    areAllSelected,
+    selectAll,
+  } = useSelectionState<IFruit>({
     items: fruits,
     isEqual: (a, b) => a.name === b.name,
     externalState: [selectedFruits, setSelectedFruits],
@@ -146,10 +141,10 @@ export const ExternalState: React.FunctionComponent = () => {
           onChange={() => toggleItemSelected(fruit)}
         />
       ))}
-      {selectedFruits.length > 0 ? (
+      {selectedItems.length > 0 ? (
         <>
           <br />
-          <p>Do something with these! {selectedFruits.map((fruit) => fruit.name).join(', ')}</p>
+          <p>Do something with these! {selectedItems.map((fruit) => fruit.name).join(', ')}</p>
         </>
       ) : null}
     </div>

--- a/src/hooks/useSelectionState/useSelectionState.ts
+++ b/src/hooks/useSelectionState/useSelectionState.ts
@@ -4,6 +4,7 @@ export interface ISelectionStateArgs<T> {
   items: T[];
   initialSelected?: T[];
   isEqual?: (a: T, b: T) => boolean;
+  externalState?: [T[], React.Dispatch<React.SetStateAction<T[]>>];
 }
 
 export interface ISelectionState<T> {
@@ -19,8 +20,10 @@ export const useSelectionState = <T>({
   items,
   initialSelected = [],
   isEqual = (a, b) => a === b,
+  externalState,
 }: ISelectionStateArgs<T>): ISelectionState<T> => {
-  const [selectedItems, setSelectedItems] = React.useState<T[]>(initialSelected);
+  const internalState = React.useState<T[]>(initialSelected);
+  const [selectedItems, setSelectedItems] = externalState || internalState;
 
   const isItemSelected = (item: T) => selectedItems.some((i) => isEqual(item, i));
 


### PR DESCRIPTION
@ibolton336 @gildub do you mind merging this ahead of my wizard state PR for virt-ui? I need it to manage the form state for the filter VMs tree without duplicating the logic from useSelectionState.

This just adds the ability to pass in the `[value, setValue]` array from outside the hook instead of using the `React.useState` that is called inside the hook, so we can get all the fancy useSelectionState logic but store the value inside useFormState and validate it.