### PR TITLE
fix(package.json): treat axios properly as an external peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ This package has React and PatternFly packages as peer dependencies, which are n
 
 When you install @konveyor/lib-ui, you should get a warning from your package manager telling you which versions to install. [Make sure you have compatible versions](https://github.com/konveyor/lib-ui/blob/master/package.json#L30) as dependencies in your app.
 
+**Note: The `axios` peer dependency is only required if you are using `modules/kube-client`.**
+
 ### Use it!
 
 In your JS/TS, Import named modules from the library, just like PatternFly:

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@types/rollup-plugin-postcss": "^2.0.0",
     "@typescript-eslint/eslint-plugin": "^3.8.0",
     "@typescript-eslint/parser": "^3.8.0",
+    "axios": "^0.20.0",
     "babel-loader": "^8.1.0",
     "babel-preset-react-app": "^9.1.2",
     "cz-conventional-changelog": "3.2.0",
@@ -83,8 +84,5 @@
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
     }
-  },
-  "dependencies": {
-    "axios": "^0.20.0"
   }
 }


### PR DESCRIPTION
Currently `axios` is both installed as a real dependency and listed as a `peerDependency` the consumer must install themselves. I only intended the latter (because it is included in rollup's `peerDepsExternal` plugin, it doesn't actually need to be bundled).

It is still needed at build time for TS types and such, so this moves it into `devDependencies`.