### PR TITLE
fix(build): import axios conditionally to make it a truly optional dependency

### DIFF
--- a/src/modules/kube-client/client.ts
+++ b/src/modules/kube-client/client.ts
@@ -1,6 +1,13 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import { KubeResource, OAuthClient, TokenExpiryHandler } from './resources/common';
-import axios, { AxiosInstance, ResponseType } from 'axios';
+
+import type { AxiosStatic, AxiosInstance, ResponseType } from 'axios';
+
+let axios: AxiosStatic;
+try {
+  axios = require('axios');
+  // eslint-disable-next-line no-empty
+} catch (e) {}
 
 export interface IClusterClient {
   list(resource: KubeResource, params?: object): Promise<any>;

--- a/src/modules/kube-client/discoveryClient.ts
+++ b/src/modules/kube-client/discoveryClient.ts
@@ -1,5 +1,12 @@
-import axios, { AxiosInstance, ResponseType } from 'axios';
 import { IDiscoveryResource, IDiscoveryParameters, OAuthClient } from './resources/common';
+
+import type { AxiosStatic, AxiosInstance, ResponseType } from 'axios';
+
+let axios: AxiosStatic;
+try {
+  axios = require('axios');
+  // eslint-disable-next-line no-empty
+} catch (e) {}
 
 export interface IDiscoveryClient {
   // eslint-disable-next-line @typescript-eslint/ban-types


### PR DESCRIPTION
Installing lib-ui without axios as a dependency was breaking the virt-ui webpack build. This should fix it (even though we'll be using axios, it shouldn't be required).