### PR TITLE
Specify 1em diameter on the spinner so it will always match the icon size

### DIFF
--- a/src/components/StatusIcon/StatusIcon.css
+++ b/src/components/StatusIcon/StatusIcon.css
@@ -1,0 +1,3 @@
+span.pf-c-spinner.status-icon-loading-spinner {
+  --pf-c-spinner--diameter: 1em;
+}

--- a/src/components/StatusIcon/StatusIcon.stories.mdx
+++ b/src/components/StatusIcon/StatusIcon.stories.mdx
@@ -22,6 +22,8 @@ WarningTriangleIcon and ExclamationCircleIcon that automatically sets the right 
     <StatusIcon status={StatusType.Error} />
     <br />
     <StatusIcon status={StatusType.Info} />
+    <br />
+    <StatusIcon status={StatusType.Loading} />
   </Story>
 </Canvas>
 
@@ -36,6 +38,8 @@ WarningTriangleIcon and ExclamationCircleIcon that automatically sets the right 
     <StatusIcon status={StatusType.Error} isDisabled />
     <br />
     <StatusIcon status={StatusType.Info} isDisabled />
+    <br />
+    <StatusIcon status={StatusType.Loading} isDisabled />
   </Story>
 </Canvas>
 
@@ -47,6 +51,7 @@ WarningTriangleIcon and ExclamationCircleIcon that automatically sets the right 
     <StatusIcon status={StatusType.Warning} label="Warning" />
     <StatusIcon status={StatusType.Error} label="Error" />
     <StatusIcon status={StatusType.Info} label="Info" />
+    <StatusIcon status={StatusType.Loading} label="Loading" />
   </Story>
 </Canvas>
 

--- a/src/components/StatusIcon/StatusIcon.stories.mdx
+++ b/src/components/StatusIcon/StatusIcon.stories.mdx
@@ -20,6 +20,8 @@ WarningTriangleIcon and ExclamationCircleIcon that automatically sets the right 
     <StatusIcon status={StatusType.Warning} />
     <br />
     <StatusIcon status={StatusType.Error} />
+    <br />
+    <StatusIcon status={StatusType.Info} />
   </Story>
 </Canvas>
 
@@ -32,6 +34,8 @@ WarningTriangleIcon and ExclamationCircleIcon that automatically sets the right 
     <StatusIcon status={StatusType.Warning} isDisabled />
     <br />
     <StatusIcon status={StatusType.Error} isDisabled />
+    <br />
+    <StatusIcon status={StatusType.Info} isDisabled />
   </Story>
 </Canvas>
 
@@ -42,6 +46,7 @@ WarningTriangleIcon and ExclamationCircleIcon that automatically sets the right 
     <StatusIcon status={StatusType.Ok} label="Ready" />
     <StatusIcon status={StatusType.Warning} label="Warning" />
     <StatusIcon status={StatusType.Error} label="Error" />
+    <StatusIcon status={StatusType.Info} label="Info" />
   </Story>
 </Canvas>
 

--- a/src/components/StatusIcon/StatusIcon.test.tsx
+++ b/src/components/StatusIcon/StatusIcon.test.tsx
@@ -9,7 +9,6 @@ import {
   global_info_color_100 as infoColor,
 } from '@patternfly/react-tokens';
 import { StatusIcon, StatusType, IStatusIconProps } from './StatusIcon';
-import { spinnerSize } from '@patternfly/react-core';
 
 const checkColor = (props: IStatusIconProps, color: string) => {
   const { container } = render(<StatusIcon {...props} />);
@@ -27,12 +26,6 @@ const checkText = (props: IStatusIconProps, text: string) => {
   const { container } = render(<StatusIcon {...props} />);
   const icon = container.querySelector('.pf-l-flex');
   expect(icon).toContainHTML(text);
-};
-
-const checkSize = (props: IStatusIconProps, size: string, selector: string) => {
-  const { container } = render(<StatusIcon {...props} />);
-  const icon = container.querySelector(selector);
-  expect(icon).toHaveClass(size);
 };
 
 describe('StatusIcon', () => {
@@ -102,9 +95,6 @@ describe('StatusIcon', () => {
     });
     it('should pass down a given className', () => {
       checkClass({ status: StatusType.Loading, className: 'foo' }, 'foo', 'span');
-    });
-    it('should pass down a given size', () => {
-      checkSize({ status: StatusType.Loading, size: spinnerSize.md }, 'pf-m-md', 'span');
     });
   });
 });

--- a/src/components/StatusIcon/StatusIcon.test.tsx
+++ b/src/components/StatusIcon/StatusIcon.test.tsx
@@ -6,6 +6,7 @@ import {
   global_success_color_100 as successColor,
   global_warning_color_100 as warningColor,
   global_danger_color_100 as dangerColor,
+  global_info_color_100 as infoColor,
 } from '@patternfly/react-tokens';
 
 import { StatusIcon, StatusType, IStatusIconProps } from './StatusIcon';
@@ -71,6 +72,21 @@ describe('StatusIcon', () => {
     });
     it('should pass down a given className', () => {
       checkClass({ status: StatusType.Error, className: 'foo' }, 'foo');
+    });
+  });
+
+  describe('Info status', () => {
+    it('should have label if present', () => {
+      checkText({ status: StatusType.Info, label: 'Info' }, 'Info');
+    });
+    it('should have correct color', () => {
+      checkColor({ status: StatusType.Info }, infoColor.value);
+    });
+    it('should have disabled color if disabled', () => {
+      checkColor({ status: StatusType.Info, isDisabled: true }, disabledColor.value);
+    });
+    it('should pass down a given className', () => {
+      checkClass({ status: StatusType.Info, className: 'foo' }, 'foo');
     });
   });
 });

--- a/src/components/StatusIcon/StatusIcon.test.tsx
+++ b/src/components/StatusIcon/StatusIcon.test.tsx
@@ -8,8 +8,8 @@ import {
   global_danger_color_100 as dangerColor,
   global_info_color_100 as infoColor,
 } from '@patternfly/react-tokens';
-
 import { StatusIcon, StatusType, IStatusIconProps } from './StatusIcon';
+import { spinnerSize } from '@patternfly/react-core';
 
 const checkColor = (props: IStatusIconProps, color: string) => {
   const { container } = render(<StatusIcon {...props} />);
@@ -17,9 +17,9 @@ const checkColor = (props: IStatusIconProps, color: string) => {
   expect(icon).toHaveAttribute('fill', color);
 };
 
-const checkClass = (props: IStatusIconProps, className: string) => {
+const checkClass = (props: IStatusIconProps, className: string, selector: string) => {
   const { container } = render(<StatusIcon {...props} />);
-  const icon = container.querySelector('svg');
+  const icon = container.querySelector(selector);
   expect(icon).toHaveClass(className);
 };
 
@@ -27,6 +27,12 @@ const checkText = (props: IStatusIconProps, text: string) => {
   const { container } = render(<StatusIcon {...props} />);
   const icon = container.querySelector('.pf-l-flex');
   expect(icon).toContainHTML(text);
+};
+
+const checkSize = (props: IStatusIconProps, size: string, selector: string) => {
+  const { container } = render(<StatusIcon {...props} />);
+  const icon = container.querySelector(selector);
+  expect(icon).toHaveClass(size);
 };
 
 describe('StatusIcon', () => {
@@ -41,7 +47,7 @@ describe('StatusIcon', () => {
       checkColor({ status: StatusType.Ok, isDisabled: true }, disabledColor.value);
     });
     it('should pass down a given className', () => {
-      checkClass({ status: StatusType.Ok, className: 'foo' }, 'foo');
+      checkClass({ status: StatusType.Ok, className: 'foo' }, 'foo', 'svg');
     });
   });
 
@@ -56,7 +62,7 @@ describe('StatusIcon', () => {
       checkColor({ status: StatusType.Warning, isDisabled: true }, disabledColor.value);
     });
     it('should pass down a given className', () => {
-      checkClass({ status: StatusType.Warning, className: 'foo' }, 'foo');
+      checkClass({ status: StatusType.Warning, className: 'foo' }, 'foo', 'svg');
     });
   });
 
@@ -71,7 +77,7 @@ describe('StatusIcon', () => {
       checkColor({ status: StatusType.Error, isDisabled: true }, disabledColor.value);
     });
     it('should pass down a given className', () => {
-      checkClass({ status: StatusType.Error, className: 'foo' }, 'foo');
+      checkClass({ status: StatusType.Error, className: 'foo' }, 'foo', 'svg');
     });
   });
 
@@ -86,7 +92,19 @@ describe('StatusIcon', () => {
       checkColor({ status: StatusType.Info, isDisabled: true }, disabledColor.value);
     });
     it('should pass down a given className', () => {
-      checkClass({ status: StatusType.Info, className: 'foo' }, 'foo');
+      checkClass({ status: StatusType.Info, className: 'foo' }, 'foo', 'svg');
+    });
+  });
+
+  describe('Loading status', () => {
+    it('should have label if present', () => {
+      checkText({ status: StatusType.Loading, label: 'Loading' }, 'Loading');
+    });
+    it('should pass down a given className', () => {
+      checkClass({ status: StatusType.Loading, className: 'foo' }, 'foo', 'span');
+    });
+    it('should pass down a given size', () => {
+      checkSize({ status: StatusType.Loading, size: spinnerSize.md }, 'pf-m-md', 'span');
     });
   });
 });

--- a/src/components/StatusIcon/StatusIcon.tsx
+++ b/src/components/StatusIcon/StatusIcon.tsx
@@ -4,18 +4,21 @@ import {
   CheckCircleIcon,
   WarningTriangleIcon,
   ExclamationCircleIcon,
+  InfoCircleIcon,
 } from '@patternfly/react-icons';
 import {
   global_disabled_color_200 as disabledColor,
   global_success_color_100 as successColor,
   global_warning_color_100 as warningColor,
   global_danger_color_100 as dangerColor,
+  global_info_color_100 as infoColor,
 } from '@patternfly/react-tokens';
 
 export enum StatusType {
   Ok = 'Ok',
   Warning = 'Warning',
   Error = 'Error',
+  Info = 'Info',
 }
 
 export interface IStatusIconProps {
@@ -53,6 +56,14 @@ export const StatusIcon: React.FunctionComponent<IStatusIconProps> = ({
       <ExclamationCircleIcon
         className={className}
         color={isDisabled ? disabledColor.value : dangerColor.value}
+      />
+    );
+  }
+  if (status === StatusType.Info) {
+    icon = (
+      <InfoCircleIcon
+        className={className}
+        color={isDisabled ? disabledColor.value : infoColor.value}
       />
     );
   }

--- a/src/components/StatusIcon/StatusIcon.tsx
+++ b/src/components/StatusIcon/StatusIcon.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Flex, FlexItem } from '@patternfly/react-core';
+import { Flex, FlexItem, Spinner, spinnerSize } from '@patternfly/react-core';
 import {
   CheckCircleIcon,
   WarningTriangleIcon,
@@ -19,6 +19,7 @@ export enum StatusType {
   Warning = 'Warning',
   Error = 'Error',
   Info = 'Info',
+  Loading = 'Loading',
 }
 
 export interface IStatusIconProps {
@@ -26,6 +27,7 @@ export interface IStatusIconProps {
   label?: React.ReactNode;
   isDisabled?: boolean;
   className?: string;
+  size?: spinnerSize;
 }
 
 export const StatusIcon: React.FunctionComponent<IStatusIconProps> = ({
@@ -33,6 +35,7 @@ export const StatusIcon: React.FunctionComponent<IStatusIconProps> = ({
   label,
   isDisabled = false,
   className = '',
+  size = spinnerSize.sm,
 }: IStatusIconProps) => {
   let icon: React.ReactElement | null = null;
   if (status === StatusType.Ok) {
@@ -66,6 +69,9 @@ export const StatusIcon: React.FunctionComponent<IStatusIconProps> = ({
         color={isDisabled ? disabledColor.value : infoColor.value}
       />
     );
+  }
+  if (status === StatusType.Loading) {
+    icon = <Spinner className={className} size={size} />;
   }
   if (label) {
     return (

--- a/src/components/StatusIcon/StatusIcon.tsx
+++ b/src/components/StatusIcon/StatusIcon.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Flex, FlexItem, Spinner, spinnerSize } from '@patternfly/react-core';
+import { Flex, FlexItem, Spinner } from '@patternfly/react-core';
 import {
   CheckCircleIcon,
   WarningTriangleIcon,
@@ -14,6 +14,8 @@ import {
   global_info_color_100 as infoColor,
 } from '@patternfly/react-tokens';
 
+import './StatusIcon.css';
+
 export enum StatusType {
   Ok = 'Ok',
   Warning = 'Warning',
@@ -27,7 +29,6 @@ export interface IStatusIconProps {
   label?: React.ReactNode;
   isDisabled?: boolean;
   className?: string;
-  size?: spinnerSize;
 }
 
 export const StatusIcon: React.FunctionComponent<IStatusIconProps> = ({
@@ -35,7 +36,6 @@ export const StatusIcon: React.FunctionComponent<IStatusIconProps> = ({
   label,
   isDisabled = false,
   className = '',
-  size = spinnerSize.sm,
 }: IStatusIconProps) => {
   let icon: React.ReactElement | null = null;
   if (status === StatusType.Ok) {
@@ -71,7 +71,7 @@ export const StatusIcon: React.FunctionComponent<IStatusIconProps> = ({
     );
   }
   if (status === StatusType.Loading) {
-    icon = <Spinner className={className} size={size} />;
+    icon = <Spinner className={`${className} status-icon-loading-spinner`} />;
   }
   if (label) {
     return (


### PR DESCRIPTION
@gildub here's a solution for your spinner spacing problem. Instead of using a size prop on the spinner at all, we can use CSS to set its diameter to `1em` which will always make it match the font size (just like the normal icons do). This makes it the exact same size as the other variants, and if you modify the font size of the container it will scale to match.