### PR TITLE
fix(ci): upgrade GitHub Pages deploy action to address deprecated set-env command

### DIFF
--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Build Storybook
         run: yarn storybook:export
       - name: Deploy Storybook to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@3.5.9
+        uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           BRANCH: gh-pages


### PR DESCRIPTION
Resolves https://github.com/konveyor/lib-ui/issues/34

See the error in this action run: https://github.com/konveyor/lib-ui/runs/1657087562?check_suite_focus=true