### PR TITLE
feat(StatusIcon): Declarative approach using union types

### DIFF
--- a/src/components/StatusIcon/StatusIcon.stories.mdx
+++ b/src/components/StatusIcon/StatusIcon.stories.mdx
@@ -1,5 +1,5 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import { StatusIcon, StatusType } from './StatusIcon';
+import { StatusIcon } from './StatusIcon';
 import GithubLink from '../../../.storybook/helpers/GithubLink';
 
 <Meta title="Components/StatusIcon" component={StatusIcon} />
@@ -15,17 +15,17 @@ WarningTriangleIcon and ExclamationCircleIcon that automatically sets the right 
 
 <Canvas>
   <Story name="Basic">
-    <StatusIcon status={StatusType.Ok} />
+    <StatusIcon status="Ok" />
     <br />
-    <StatusIcon status={StatusType.Warning} />
+    <StatusIcon status="Warning" />
     <br />
-    <StatusIcon status={StatusType.Error} />
+    <StatusIcon status="Error" />
     <br />
-    <StatusIcon status={StatusType.Info} />
+    <StatusIcon status="Info" />
     <br />
-    <StatusIcon status={StatusType.Loading} />
+    <StatusIcon status="Loading" />
     <br />
-    <StatusIcon status={StatusType.Unknown} />
+    <StatusIcon status="Unknown" />
   </Story>
 </Canvas>
 
@@ -33,17 +33,17 @@ WarningTriangleIcon and ExclamationCircleIcon that automatically sets the right 
 
 <Canvas>
   <Story name="Disabled">
-    <StatusIcon status={StatusType.Ok} isDisabled />
+    <StatusIcon status="Ok" isDisabled />
     <br />
-    <StatusIcon status={StatusType.Warning} isDisabled />
+    <StatusIcon status="Warning" isDisabled />
     <br />
-    <StatusIcon status={StatusType.Error} isDisabled />
+    <StatusIcon status="Error" isDisabled />
     <br />
-    <StatusIcon status={StatusType.Info} isDisabled />
+    <StatusIcon status="Info" isDisabled />
     <br />
-    <StatusIcon status={StatusType.Loading} isDisabled />
+    <StatusIcon status="Loading" isDisabled />
     <br />
-    <StatusIcon status={StatusType.Unknown} isDisabled />
+    <StatusIcon status="Unknown" isDisabled />
   </Story>
 </Canvas>
 
@@ -51,12 +51,12 @@ WarningTriangleIcon and ExclamationCircleIcon that automatically sets the right 
 
 <Canvas>
   <Story name="With label">
-    <StatusIcon status={StatusType.Ok} label="Ready" />
-    <StatusIcon status={StatusType.Warning} label="Warning" />
-    <StatusIcon status={StatusType.Error} label="Error" />
-    <StatusIcon status={StatusType.Info} label="Info" />
-    <StatusIcon status={StatusType.Loading} label="Loading" />
-    <StatusIcon status={StatusType.Unknown} label="Unknown" />
+    <StatusIcon status="Ok" label="Ready" />
+    <StatusIcon status="Warning" label="Warning" />
+    <StatusIcon status="Error" label="Error" />
+    <StatusIcon status="Info" label="Info" />
+    <StatusIcon status="Loading" label="Loading" />
+    <StatusIcon status="Unknown" label="Unknown" />
   </Story>
 </Canvas>
 

--- a/src/components/StatusIcon/StatusIcon.test.tsx
+++ b/src/components/StatusIcon/StatusIcon.test.tsx
@@ -9,7 +9,7 @@ import {
   global_danger_color_100 as dangerColor,
   global_info_color_100 as infoColor,
 } from '@patternfly/react-tokens';
-import { StatusIcon, StatusType, IStatusIconProps } from './StatusIcon';
+import { StatusIcon, IStatusIconProps } from './StatusIcon';
 
 const checkColor = (props: IStatusIconProps, color: string) => {
   const { container } = render(<StatusIcon {...props} />);
@@ -32,85 +32,85 @@ const checkText = (props: IStatusIconProps, text: string) => {
 describe('StatusIcon', () => {
   describe('Ok status', () => {
     it('should have label if present', () => {
-      checkText({ status: StatusType.Ok, label: 'Ready' }, 'Ready');
+      checkText({ status: 'Ok', label: 'Ready' }, 'Ready');
     });
     it('should have correct color', () => {
-      checkColor({ status: StatusType.Ok }, successColor.value);
+      checkColor({ status: 'Ok' }, successColor.value);
     });
     it('should have disabled color if disabled', () => {
-      checkColor({ status: StatusType.Ok, isDisabled: true }, disabledColor.value);
+      checkColor({ status: 'Ok', isDisabled: true }, disabledColor.value);
     });
     it('should pass down a given className', () => {
-      checkClass({ status: StatusType.Ok, className: 'foo' }, 'foo', 'svg');
+      checkClass({ status: 'Ok', className: 'foo' }, 'foo', 'svg');
     });
   });
 
   describe('Warning status', () => {
     it('should have label if present', () => {
-      checkText({ status: StatusType.Warning, label: 'Warning' }, 'Warning');
+      checkText({ status: 'Warning', label: 'Warning' }, 'Warning');
     });
     it('should have correct color', () => {
-      checkColor({ status: StatusType.Warning }, warningColor.value);
+      checkColor({ status: 'Warning' }, warningColor.value);
     });
     it('should have disabled color if disabled', () => {
-      checkColor({ status: StatusType.Warning, isDisabled: true }, disabledColor.value);
+      checkColor({ status: 'Warning', isDisabled: true }, disabledColor.value);
     });
     it('should pass down a given className', () => {
-      checkClass({ status: StatusType.Warning, className: 'foo' }, 'foo', 'svg');
+      checkClass({ status: 'Warning', className: 'foo' }, 'foo', 'svg');
     });
   });
 
   describe('Error status', () => {
     it('should have label if present', () => {
-      checkText({ status: StatusType.Error, label: 'Error' }, 'Error');
+      checkText({ status: 'Error', label: 'Error' }, 'Error');
     });
     it('should have correct color', () => {
-      checkColor({ status: StatusType.Error }, dangerColor.value);
+      checkColor({ status: 'Error' }, dangerColor.value);
     });
     it('should have disabled color if disabled', () => {
-      checkColor({ status: StatusType.Error, isDisabled: true }, disabledColor.value);
+      checkColor({ status: 'Error', isDisabled: true }, disabledColor.value);
     });
     it('should pass down a given className', () => {
-      checkClass({ status: StatusType.Error, className: 'foo' }, 'foo', 'svg');
+      checkClass({ status: 'Error', className: 'foo' }, 'foo', 'svg');
     });
   });
 
   describe('Info status', () => {
     it('should have label if present', () => {
-      checkText({ status: StatusType.Info, label: 'Info' }, 'Info');
+      checkText({ status: 'Info', label: 'Info' }, 'Info');
     });
     it('should have correct color', () => {
-      checkColor({ status: StatusType.Info }, infoColor.value);
+      checkColor({ status: 'Info' }, infoColor.value);
     });
     it('should have disabled color if disabled', () => {
-      checkColor({ status: StatusType.Info, isDisabled: true }, disabledColor.value);
+      checkColor({ status: 'Info', isDisabled: true }, disabledColor.value);
     });
     it('should pass down a given className', () => {
-      checkClass({ status: StatusType.Info, className: 'foo' }, 'foo', 'svg');
+      checkClass({ status: 'Info', className: 'foo' }, 'foo', 'svg');
     });
   });
 
   describe('Loading status', () => {
     it('should have label if present', () => {
-      checkText({ status: StatusType.Loading, label: 'Loading' }, 'Loading');
+      checkText({ status: 'Loading', label: 'Loading' }, 'Loading');
     });
     it('should pass down a given className', () => {
-      checkClass({ status: StatusType.Loading, className: 'foo' }, 'foo', 'span');
+      checkClass({ status: 'Loading', className: 'foo' }, 'foo', 'span');
     });
   });
 
   describe('Unknown status', () => {
     it('should have label if present', () => {
-      checkText({ status: StatusType.Unknown, label: 'Unknown' }, 'Unknown');
+      checkText({ status: 'Unknown', label: 'Unknown' }, 'Unknown');
     });
     it('should have correct color', () => {
-      checkColor({ status: StatusType.Unknown }, unknownColor.value);
+      checkColor({ status: 'Unknown' }, unknownColor.value);
     });
     it('should have disabled color if disabled', () => {
-      checkColor({ status: StatusType.Unknown, isDisabled: true }, disabledColor.value);
+      checkColor({ status: 'Unknown', isDisabled: true }, disabledColor.value);
     });
     it('should pass down a given className', () => {
-      checkClass({ status: StatusType.Unknown, className: 'foo' }, 'foo', 'svg');
+      checkClass({ status: 'Unknown', className: 'foo' }, 'foo', 'svg');
     });
   });
 });

--- a/src/components/StatusIcon/StatusIcon.tsx
+++ b/src/components/StatusIcon/StatusIcon.tsx
@@ -32,27 +32,27 @@ export type StatusIconType = keyof typeof StatusType;
 
 type IconType =
   | {
-      icon: typeof CheckCircleIcon;
+      Icon: typeof CheckCircleIcon;
       color: typeof successColor;
     }
   | {
-      icon: typeof ExclamationTriangleIcon;
+      Icon: typeof ExclamationTriangleIcon;
       color: typeof warningColor;
     }
   | {
-      icon: typeof ExclamationCircleIcon;
+      Icon: typeof ExclamationCircleIcon;
       color: typeof errorColor;
     }
   | {
-      icon: typeof InfoCircleIcon;
+      Icon: typeof InfoCircleIcon;
       color: typeof infoColor;
     }
   | {
-      icon: typeof Spinner;
+      Icon: typeof Spinner;
       color: typeof loadingColor;
     }
   | {
-      icon: typeof QuestionCircleIcon;
+      Icon: typeof QuestionCircleIcon;
       color: typeof unknownColor;
     };
 
@@ -60,27 +60,27 @@ type iconListType = { [key in StatusIconType]: IconType };
 
 const iconList: iconListType = {
   [StatusType.Ok]: {
-    icon: CheckCircleIcon,
+    Icon: CheckCircleIcon,
     color: successColor,
   },
   [StatusType.Warning]: {
-    icon: ExclamationCircleIcon,
+    Icon: ExclamationCircleIcon,
     color: warningColor,
   },
   [StatusType.Error]: {
-    icon: ExclamationCircleIcon,
+    Icon: ExclamationCircleIcon,
     color: errorColor,
   },
   [StatusType.Info]: {
-    icon: InfoCircleIcon,
+    Icon: InfoCircleIcon,
     color: infoColor,
   },
   [StatusType.Loading]: {
-    icon: Spinner,
+    Icon: Spinner,
     color: loadingColor,
   },
   [StatusType.Unknown]: {
-    icon: QuestionCircleIcon,
+    Icon: QuestionCircleIcon,
     color: unknownColor,
   },
 };
@@ -98,25 +98,29 @@ export const StatusIcon: React.FunctionComponent<IStatusIconProps> = ({
   isDisabled = false,
   className = '',
 }: IStatusIconProps) => {
-  const Icon = iconList[status].icon;
+  const Icon = iconList[status].Icon;
+  const icon = (
+    <Icon
+      color={isDisabled ? disabledColor.value : iconList[status].color.value}
+      className={
+        status === StatusType.Loading ? `${className} status-icon-loading-spinner` : className
+      }
+    />
+  );
 
-  return label ? (
-    <Flex
-      spaceItems={{ default: 'spaceItemsSm' }}
-      alignItems={{ default: 'alignItemsCenter' }}
-      flexWrap={{ default: 'nowrap' }}
-      style={{ whiteSpace: 'nowrap' }}
-      className={className}
-    >
-      <FlexItem>
-        <Icon
-          color={isDisabled ? disabledColor.value : iconList[status].color.value}
-          className={
-            status === StatusType.Loading ? `${className} status-icon-loading-spinner` : className
-          }
-        />
-      </FlexItem>
-      <FlexItem>{label}</FlexItem>
-    </Flex>
-  ) : null;
+  if (label) {
+    return (
+      <Flex
+        spaceItems={{ default: 'spaceItemsSm' }}
+        alignItems={{ default: 'alignItemsCenter' }}
+        flexWrap={{ default: 'nowrap' }}
+        style={{ whiteSpace: 'nowrap' }}
+        className={className}
+      >
+        <FlexItem>{icon}</FlexItem>
+        <FlexItem>{label}</FlexItem>
+      </Flex>
+    );
+  }
+  return icon;
 };

--- a/src/components/StatusIcon/StatusIcon.tsx
+++ b/src/components/StatusIcon/StatusIcon.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Flex, FlexItem, Spinner } from '@patternfly/react-core';
+import { Flex, FlexItem, Spinner, SpinnerProps } from '@patternfly/react-core';
 import {
   CheckCircleIcon,
   ExclamationTriangleIcon,
@@ -7,8 +7,7 @@ import {
   InfoCircleIcon,
   QuestionCircleIcon,
 } from '@patternfly/react-icons';
-import { SpinnerProps } from '@patternfly/react-core/dist/esm/components';
-import { SVGIconProps } from '@patternfly/react-icons/dist/esm/createIcon';
+import { SVGIconProps } from '@patternfly/react-icons/dist/js/createIcon';
 import {
   global_disabled_color_200 as disabledColor,
   global_success_color_100 as successColor,
@@ -44,7 +43,7 @@ const iconList: IconListType = {
     color: successColor,
   },
   [StatusType.Warning]: {
-    Icon: ExclamationCircleIcon,
+    Icon: ExclamationTriangleIcon,
     color: warningColor,
   },
   [StatusType.Error]: {

--- a/src/components/StatusIcon/StatusIcon.tsx
+++ b/src/components/StatusIcon/StatusIcon.tsx
@@ -7,6 +7,8 @@ import {
   InfoCircleIcon,
   QuestionCircleIcon,
 } from '@patternfly/react-icons';
+import { SpinnerProps } from '@patternfly/react-core/dist/esm/components';
+import { SVGIconProps } from '@patternfly/react-icons/dist/esm/createIcon';
 import {
   global_disabled_color_200 as disabledColor,
   global_success_color_100 as successColor,
@@ -30,34 +32,12 @@ export enum StatusType {
 
 export type StatusIconType = keyof typeof StatusType;
 
-type IconType =
-  | {
-      Icon: typeof CheckCircleIcon;
-      color: typeof successColor;
-    }
-  | {
-      Icon: typeof ExclamationTriangleIcon;
-      color: typeof warningColor;
-    }
-  | {
-      Icon: typeof ExclamationCircleIcon;
-      color: typeof errorColor;
-    }
-  | {
-      Icon: typeof InfoCircleIcon;
-      color: typeof infoColor;
-    }
-  | {
-      Icon: typeof Spinner;
-      color: typeof loadingColor;
-    }
-  | {
-      Icon: typeof QuestionCircleIcon;
-      color: typeof unknownColor;
-    };
-
-type IconListType = { [key in StatusIconType]: IconType };
-
+type IconListType = {
+  [key in StatusType]: {
+    Icon: React.ComponentClass<SVGIconProps> | React.FunctionComponent<SpinnerProps>;
+    color: { name: string; value: string; var: string };
+  };
+};
 const iconList: IconListType = {
   [StatusType.Ok]: {
     Icon: CheckCircleIcon,

--- a/src/components/StatusIcon/StatusIcon.tsx
+++ b/src/components/StatusIcon/StatusIcon.tsx
@@ -56,9 +56,9 @@ type IconType =
       color: typeof unknownColor;
     };
 
-type iconListType = { [key in StatusIconType]: IconType };
+type IconListType = { [key in StatusIconType]: IconType };
 
-const iconList: iconListType = {
+const iconList: IconListType = {
   [StatusType.Ok]: {
     Icon: CheckCircleIcon,
     color: successColor,

--- a/src/components/StatusIcon/StatusIcon.tsx
+++ b/src/components/StatusIcon/StatusIcon.tsx
@@ -12,8 +12,9 @@ import {
   global_success_color_100 as successColor,
   global_warning_color_100 as warningColor,
   global_Color_dark_200 as unknownColor,
-  global_danger_color_100 as dangerColor,
+  global_danger_color_100 as errorColor,
   global_info_color_100 as infoColor,
+  global_info_color_200 as loadingColor,
 } from '@patternfly/react-tokens';
 
 import './StatusIcon.css';
@@ -27,8 +28,65 @@ export enum StatusType {
   Unknown = 'Unknown',
 }
 
+export type StatusIconType = keyof typeof StatusType;
+
+type IconType =
+  | {
+      icon: typeof CheckCircleIcon;
+      color: typeof successColor;
+    }
+  | {
+      icon: typeof ExclamationTriangleIcon;
+      color: typeof warningColor;
+    }
+  | {
+      icon: typeof ExclamationCircleIcon;
+      color: typeof errorColor;
+    }
+  | {
+      icon: typeof InfoCircleIcon;
+      color: typeof infoColor;
+    }
+  | {
+      icon: typeof Spinner;
+      color: typeof loadingColor;
+    }
+  | {
+      icon: typeof QuestionCircleIcon;
+      color: typeof unknownColor;
+    };
+
+type iconListType = { [key in StatusIconType]: IconType };
+
+const iconList: iconListType = {
+  [StatusType.Ok]: {
+    icon: CheckCircleIcon,
+    color: successColor,
+  },
+  [StatusType.Warning]: {
+    icon: ExclamationCircleIcon,
+    color: warningColor,
+  },
+  [StatusType.Error]: {
+    icon: ExclamationCircleIcon,
+    color: errorColor,
+  },
+  [StatusType.Info]: {
+    icon: InfoCircleIcon,
+    color: infoColor,
+  },
+  [StatusType.Loading]: {
+    icon: Spinner,
+    color: loadingColor,
+  },
+  [StatusType.Unknown]: {
+    icon: QuestionCircleIcon,
+    color: unknownColor,
+  },
+};
+
 export interface IStatusIconProps {
-  status: StatusType;
+  status: StatusIconType;
   label?: React.ReactNode;
   isDisabled?: boolean;
   className?: string;
@@ -40,63 +98,25 @@ export const StatusIcon: React.FunctionComponent<IStatusIconProps> = ({
   isDisabled = false,
   className = '',
 }: IStatusIconProps) => {
-  let icon: React.ReactElement | null = null;
-  if (status === StatusType.Ok) {
-    icon = (
-      <CheckCircleIcon
-        className={className}
-        color={isDisabled ? disabledColor.value : successColor.value}
-      />
-    );
-  }
-  if (status === StatusType.Warning) {
-    icon = (
-      <ExclamationTriangleIcon
-        className={className}
-        color={isDisabled ? disabledColor.value : warningColor.value}
-      />
-    );
-  }
-  if (status === StatusType.Error) {
-    icon = (
-      <ExclamationCircleIcon
-        className={className}
-        color={isDisabled ? disabledColor.value : dangerColor.value}
-      />
-    );
-  }
-  if (status === StatusType.Info) {
-    icon = (
-      <InfoCircleIcon
-        className={className}
-        color={isDisabled ? disabledColor.value : infoColor.value}
-      />
-    );
-  }
-  if (status === StatusType.Loading) {
-    icon = <Spinner className={`${className} status-icon-loading-spinner`} />;
-  }
-  if (status === StatusType.Unknown) {
-    icon = (
-      <QuestionCircleIcon
-        className={className}
-        color={isDisabled ? disabledColor.value : unknownColor.value}
-      />
-    );
-  }
-  if (label) {
-    return (
-      <Flex
-        spaceItems={{ default: 'spaceItemsSm' }}
-        alignItems={{ default: 'alignItemsCenter' }}
-        flexWrap={{ default: 'nowrap' }}
-        style={{ whiteSpace: 'nowrap' }}
-        className={className}
-      >
-        <FlexItem>{icon}</FlexItem>
-        <FlexItem>{label}</FlexItem>
-      </Flex>
-    );
-  }
-  return icon;
+  const Icon = iconList[status].icon;
+
+  return label ? (
+    <Flex
+      spaceItems={{ default: 'spaceItemsSm' }}
+      alignItems={{ default: 'alignItemsCenter' }}
+      flexWrap={{ default: 'nowrap' }}
+      style={{ whiteSpace: 'nowrap' }}
+      className={className}
+    >
+      <FlexItem>
+        <Icon
+          color={isDisabled ? disabledColor.value : iconList[status].color.value}
+          className={
+            status === StatusType.Loading ? `${className} status-icon-loading-spinner` : className
+          }
+        />
+      </FlexItem>
+      <FlexItem>{label}</FlexItem>
+    </Flex>
+  ) : null;
 };

--- a/src/components/StatusIcon/StatusIcon.tsx
+++ b/src/components/StatusIcon/StatusIcon.tsx
@@ -20,16 +20,7 @@ import {
 
 import './StatusIcon.css';
 
-export enum StatusType {
-  Ok = 'Ok',
-  Warning = 'Warning',
-  Error = 'Error',
-  Info = 'Info',
-  Loading = 'Loading',
-  Unknown = 'Unknown',
-}
-
-export type StatusIconType = keyof typeof StatusType;
+export type StatusType = 'Ok' | 'Warning' | 'Error' | 'Info' | 'Loading' | 'Unknown';
 
 type IconListType = {
   [key in StatusType]: {
@@ -38,34 +29,34 @@ type IconListType = {
   };
 };
 const iconList: IconListType = {
-  [StatusType.Ok]: {
+  Ok: {
     Icon: CheckCircleIcon,
     color: successColor,
   },
-  [StatusType.Warning]: {
+  Warning: {
     Icon: ExclamationTriangleIcon,
     color: warningColor,
   },
-  [StatusType.Error]: {
+  Error: {
     Icon: ExclamationCircleIcon,
     color: errorColor,
   },
-  [StatusType.Info]: {
+  Info: {
     Icon: InfoCircleIcon,
     color: infoColor,
   },
-  [StatusType.Loading]: {
+  Loading: {
     Icon: Spinner,
     color: loadingColor,
   },
-  [StatusType.Unknown]: {
+  Unknown: {
     Icon: QuestionCircleIcon,
     color: unknownColor,
   },
 };
 
 export interface IStatusIconProps {
-  status: StatusIconType;
+  status: StatusType;
   label?: React.ReactNode;
   isDisabled?: boolean;
   className?: string;
@@ -81,9 +72,7 @@ export const StatusIcon: React.FunctionComponent<IStatusIconProps> = ({
   const icon = (
     <Icon
       color={isDisabled ? disabledColor.value : iconList[status].color.value}
-      className={
-        status === StatusType.Loading ? `${className} status-icon-loading-spinner` : className
-      }
+      className={status === 'Loading' ? `${className} status-icon-loading-spinner` : className}
     />
   );
 


### PR DESCRIPTION
BREAKING CHANGE: `statusType` prop of the `StatusIcon` component is now a string, and the `StatusType` enum is no longer exported.

Replaces string enums with unions types.
Use lookup table for icons.  

https://github.com/konveyor/lib-ui/issues/48