### PR TITLE
fix(useformstate): hotfix: we needed AnySchema<T> instead of SchemaOf<T> for the yup breaking change

### DIFF
--- a/src/hooks/useFormState/useFormState.ts
+++ b/src/hooks/useFormState/useFormState.ts
@@ -12,7 +12,7 @@ export interface IFormField<T> {
   isTouched: boolean;
   setIsTouched: (isTouched: boolean) => void;
   reset: () => void;
-  schema: yup.SchemaOf<T>;
+  schema: yup.AnySchema<T>;
 }
 
 export interface IValidatedFormField<T> extends IFormField<T> {
@@ -52,7 +52,7 @@ export interface IFormState<TFieldValues> {
 
 export const useFormField = <T>(
   initialValue: T,
-  schema: yup.SchemaOf<T>,
+  schema: yup.AnySchema<T>,
   options: { initialTouched?: boolean } = {}
 ): IFormField<T> => {
   const [initializedValue, setInitializedValue] = React.useState<T>(initialValue);
@@ -109,7 +109,7 @@ export const useFormState = <TFieldValues>(
       lastValuesRef.current = values;
       const schemaShape = fieldKeys.reduce(
         (newObj, key) => ({ ...newObj, [key]: fields[key].schema }),
-        {} as { [key in keyof TFieldValues]: yup.SchemaOf<TFieldValues[key]> }
+        {} as { [key in keyof TFieldValues]: yup.AnySchema<TFieldValues[key]> }
       );
       const schema = yup.object().shape(schemaShape);
       setHasRunInitialValidation(true);


### PR DESCRIPTION
I screwed up in #57.

useFormState and useFormField now require `yup.AnySchema<T>` schema types instead of the `yup.SchemaOf<T>` which was not behaving correctly with boolean fields.