### PR TITLE
Add preserveOrder option to useSelectionState for a performance bonus

### DIFF
--- a/src/hooks/useSelectionState/useSelectionState.stories.mdx
+++ b/src/hooks/useSelectionState/useSelectionState.stories.mdx
@@ -24,6 +24,7 @@ interface ISelectionStateArgs<T> {
   initialSelected?: T[]; // Defaults to []
   isEqual?: (a: T, b: T) => boolean; // Defaults to (a, b) => a === b
   externalState?: [T[], React.Dispatch<React.SetStateAction<T[]>>];
+  preserveOrder?: boolean; // Defaults to true
 }
 
 // Return value:
@@ -56,6 +57,12 @@ For example, if your items have `id` properties, you can use `isEqual: (a, b) =>
 If necessary, you can pass the optional `externalState` prop in order to manage the actual selections array itself from outside the hook.
 This may be useful if you need to manage the state as part of a centralized form, but you still want the logic from these methods.
 The type of `externalState` is the same as the array returned from `React.useState` (a tuple of `value` and `setValue`.)
+
+## A note about order and performance
+
+By default, the `preserveOrder` option is on. This means that each time the selection is changed, the hook traverses the entire list of
+items so that `selectedItems` is in the same order as the original `items`. With `preserveOrder: false`, `selectedItems` is instead in
+the order the items were selected, but performance is slightly better.
 
 ## Examples
 

--- a/src/hooks/useSelectionState/useSelectionState.ts
+++ b/src/hooks/useSelectionState/useSelectionState.ts
@@ -5,6 +5,7 @@ export interface ISelectionStateArgs<T> {
   initialSelected?: T[];
   isEqual?: (a: T, b: T) => boolean;
   externalState?: [T[], React.Dispatch<React.SetStateAction<T[]>>];
+  preserveOrder?: boolean;
 }
 
 export interface ISelectionState<T> {
@@ -22,6 +23,7 @@ export const useSelectionState = <T>({
   initialSelected = [],
   isEqual = (a, b) => a === b,
   externalState,
+  preserveOrder = true,
 }: ISelectionStateArgs<T>): ISelectionState<T> => {
   const internalState = React.useState<T[]>(initialSelected);
   const [selectedItems, setSelectedItems] = externalState || internalState;
@@ -50,11 +52,9 @@ export const useSelectionState = <T>({
   const selectAll = (isSelecting = true) => setSelectedItems(isSelecting ? items : []);
   const areAllSelected = selectedItems.length === items.length;
 
-  // Preserve original order of items
-  let selectedItemsInOrder: T[] = [];
-  if (areAllSelected) {
-    selectedItemsInOrder = items;
-  } else if (selectedItems.length > 0) {
+  let selectedItemsInOrder: T[] = selectedItems;
+  if (preserveOrder && !areAllSelected && selectedItems.length > 0) {
+    // Preserve original order of items (slight performance cost: traverses all items on every selection change)
     selectedItemsInOrder = items.filter(isItemSelected);
   }
 


### PR DESCRIPTION
Provides an option to circumvent the behavior of `useSelectionState` that ensures the order of selected items matches the order of the provided items. In cases where this order doesn't matter, this can slightly improve performance.