### PR TITLE
feat(useformstate): replace setInitialValue/reset with prefill/revert and reinitialize/clear

### DIFF
--- a/src/hooks/useFormState/useFormState.stories.mdx
+++ b/src/hooks/useFormState/useFormState.stories.mdx
@@ -147,9 +147,8 @@ For this, you can use the `prefill` function on each field object. This changes 
 Here, the submit button is only enabled if the form is dirty, so you can clearly see whether changes have been made to the object from the network that we're editing.
 The revert button also changes the values back to the values we got from the network instead of clearing the form.
 
-Note that we have separate buttons here for "Revert" and "Clear". The `revert` function sets each form field to its `cleanValue`, which was changed by the `prefill` function to correspond to the
-current "unchanged" version of this object we have on the server. The `clear` function instead sets each form field to its `defaultValue`, which is the initial value passed into `useFormField`.
-If we want to instead change those actual defaults, we can use the `reinitialize` function.
+Note that we have separate buttons here for "Revert" and "Clear". The `revert` function sets each field to its `cleanValue` (which can be changed by `prefill`), and the `clear` function sets each
+field to its `defaultValue` (which can be changed by `reinitialize`). Both default to the `initialValue` originally passed into `useFormField`.
 
 This distinction between clean/prefilled and default/initialized values is useful in cases like this where we only want to enable the submit button if the values have been changed compared to
 our real server-side data, but we also want to provide a way to clear the form back to a truly empty state.

--- a/src/hooks/useFormState/useFormState.stories.mdx
+++ b/src/hooks/useFormState/useFormState.stories.mdx
@@ -50,11 +50,16 @@ function useFormState<TFieldValues>(
 interface IFormField<T> {
   value: T;
   setValue: React.Dispatch<React.SetStateAction<T>>;
-  isDirty: boolean; // true if the value is different from initialValue by deep comparison
+  defaultValue: T;
+  cleanValue: T;
+  reinitialize: (value: T) => void; // Sets defaultValue, cleanValue and value
+  prefill: (value: T) => void; // Sets cleanValue and value
+  clear: () => void; // Sets value to defaultValue
+  revert: () => void; // Sets value to cleanValue
+  isDirty: boolean; // True if value is different from cleanValue
   isTouched: boolean;
   setIsTouched: (isTouched: boolean) => void;
-  reset: () => void;
-  schema: [T] extends [Array<infer E>] ? yup.ArraySchema<E> : yup.Schema<T>;
+  schema: yup.AnySchema<T>;
 }
 
 interface IValidatedFormField<T> extends IFormField<T> {
@@ -63,14 +68,13 @@ interface IValidatedFormField<T> extends IFormField<T> {
 }
 
 interface IFormState<TFieldValues> {
-  fields: {
-    // The same fields object passed into useFormState, but with error and isValid properties added
-    [key in keyof TFieldValues]: IValidatedFormField<TFieldValues[key]>;
-  };
+  fields: ValidatedFormFields<TFieldValues>;
   values: TFieldValues; // For convenience in submitting forms (values are also included in fields property)
-  isDirty: boolean; // true if any field has isDirty
-  isValid: boolean; // true if every field has isValid
-  reset: () => void;
+  isDirty: boolean;
+  isValid: boolean;
+  isTouched: boolean;
+  clear: () => void;
+  revert: () => void;
 }
 ```
 
@@ -138,10 +142,17 @@ If you're having trouble with yup schema types resolving to `T | undefined` inst
 If the form's initial values are known when it is first rendered, they can simply be passed as the `initialValue` arguments of each `useFormField` call.
 However, let's say you're using a form to edit some object you're loading from the network and you need to wait for that request to resolve before you pre-fill the form.
 
-For this, you can use the `setInitialValue` function on each field object. This changes the current field value, but it also changes the value used to determine if the form `isDirty` and used when `reset`ing the form.
+For this, you can use the `prefill` function on each field object. This changes the current field value, but it also changes the `cleanValue` (used to determine if the form `isDirty` and used when `revert`ing the form).
 
 Here, the submit button is only enabled if the form is dirty, so you can clearly see whether changes have been made to the object from the network that we're editing.
-The reset button also changes the values back to the values we got from the network instead of clearing the form.
+The revert button also changes the values back to the values we got from the network instead of clearing the form.
+
+Note that we have separate buttons here for "Revert" and "Clear". The `revert` function sets each form field to its `cleanValue`, which was changed by the `prefill` function to correspond to the
+current "unchanged" version of this object we have on the server. The `clear` function instead sets each form field to its `defaultValue`, which is the initial value passed into `useFormField`.
+If we want to instead change those actual defaults, we can use the `reinitialize` function.
+
+This distinction between clean/prefilled and default/initialized values is useful in cases like this where we only want to enable the submit button if the values have been changed compared to
+our real server-side data, but we also want to provide a way to clear the form back to a truly empty state.
 
 <Canvas>
   <Story story={AsyncPrefilling} />

--- a/src/hooks/useFormState/useFormState.stories.tsx
+++ b/src/hooks/useFormState/useFormState.stories.tsx
@@ -52,8 +52,8 @@ export const BasicTextFields: React.FunctionComponent = () => {
       >
         Submit
       </button>
-      <button disabled={!form.isDirty} onClick={form.reset} style={{ marginLeft: 5 }}>
-        Reset
+      <button disabled={!form.isDirty} onClick={form.clear} style={{ marginLeft: 5 }}>
+        Clear
       </button>
     </>
   );
@@ -105,8 +105,8 @@ export const PatternFlyTextFields: React.FunctionComponent = () => {
         >
           Submit
         </Button>
-        <Button variant="secondary" isDisabled={!form.isDirty} onClick={form.reset}>
-          Reset
+        <Button variant="secondary" isDisabled={!form.isDirty} onClick={form.clear}>
+          Clear
         </Button>
       </Flex>
     </Form>
@@ -144,8 +144,8 @@ export const PatternFlyTextFieldsWithHelpers: React.FunctionComponent = () => {
         >
           Submit
         </Button>
-        <Button variant="secondary" isDisabled={!form.isDirty} onClick={form.reset}>
-          Reset
+        <Button variant="secondary" isDisabled={!form.isDirty} onClick={form.clear}>
+          Clear
         </Button>
       </Flex>
     </Form>
@@ -164,8 +164,8 @@ export const AsyncPrefilling: React.FunctionComponent = () => {
     if (isLoading) {
       setTimeout(() => {
         const objectFromServer = { name: 'Existing name', description: 'Existing description' };
-        form.fields.name.setInitialValue(objectFromServer.name);
-        form.fields.description.setInitialValue(objectFromServer.description);
+        form.fields.name.prefill(objectFromServer.name);
+        form.fields.description.prefill(objectFromServer.description);
         setIsLoading(false);
       }, 1000);
     }
@@ -198,8 +198,11 @@ export const AsyncPrefilling: React.FunctionComponent = () => {
         >
           Submit
         </Button>
-        <Button variant="secondary" isDisabled={!form.isDirty} onClick={form.reset}>
-          Reset
+        <Button variant="secondary" isDisabled={!form.isDirty} onClick={form.revert}>
+          Revert
+        </Button>
+        <Button variant="secondary" isDisabled={!form.isDirty} onClick={form.clear}>
+          Clear
         </Button>
       </Flex>
     </Form>
@@ -293,8 +296,8 @@ export const ComplexFieldTypes: React.FunctionComponent = () => {
       >
         Submit
       </button>
-      <button disabled={!form.isDirty} onClick={form.reset} style={{ marginLeft: 5 }}>
-        Reset
+      <button disabled={!form.isDirty} onClick={form.clear} style={{ marginLeft: 5 }}>
+        Clear
       </button>
     </>
   );


### PR DESCRIPTION
Needed for https://github.com/konveyor/forklift-ui/issues/625, see the description there for more context.

Currently, we have a `setInitialValue` function that changes a field's `initializedValue`, which is used to determine the field's `isDirty` property (whether it differs from the current value) and is used when calling `reset()`.

The problem is, in the PlanWizard in forklift-ui we want to be able to prefill values asynchronously (currently using `setInitialValue`) and retain that behavior of `isDirty` being false if the values still match the prefilled values (so we don't get an enabled Next/Submit button until the user actually changes something), but also have the ability to clear the form to empty values rather than the prefilled ones. (necessary when the user changes provider types while editing a plan).

The solution I came up with (and I acknowledge these names may not be ideal) is:
* Rename the current `initializedValue` , `setInitialValue` and `reset` to `defaultValue`, `reinitialize` and `clear`.
* Add new `cleanValue` with `prefill` and `revert` functions. Use this for determining `isDirty`.

Most forms will not use either of these, or will only use `prefill`. But in this special case for PlanWizard, we'll be able to `prefill` from the plan being edited but also retain the actual default values that are used when creating a new plan, so that we can get them back with `clear()`.

BREAKING CHANGE: `setInitialValue` and `reset` have been replaced with `reinitialize` and `clear`. For better `isDirty` behavior you may want to use `prefill` instead of `reinitialize`.
