### PR TITLE
docs(storybook): switch Storybook deployment from GitHub Pages to Surge to avoid DNS issues

### DIFF
--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -28,9 +28,7 @@ jobs:
         run: yarn run semantic-release
       - name: Build Storybook
         run: yarn storybook:export
-      - name: Deploy Storybook to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@3.7.1
-        with:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: storybook-static
+      - name: Install Surge
+        run: npm install -g surge
+      - name: Deploy Storybook to Surge
+        run: surge ./storybook-static/ konveyor-lib-ui.surge.sh --token 62bd7a07b9bf812ff8d3ea91ccd2dc2f

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The React components in this library are compositions and extensions of [pattern
 
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
-Documentation and examples (Storybook): http://konveyor.github.io/lib-ui/
+Documentation and examples (Storybook): http://konveyor-lib-ui.surge.sh/
 
 ## Usage
 


### PR DESCRIPTION
Our Storybook docs were originally deployed to konveyor.github.io/lib-ui, which now redirects to konveyor.io/lib-ui. This worked for a while, but has since become a 404 now that the new konveyor.io website has been published.

We could figure this out and restore the usage of either konveyor.io or github.io later, but the audience for these docs is internal and small and I don't think it's necessarily worth the effort. This PR gets our docs back online by moving our main Storybook deployment to Surge, like our PR previews. The new URL is http://konveyor-lib-ui.surge.sh/.