### PR TITLE
Revert "docs(storybook): switch Storybook deployment from GitHub Pages to Surge to avoid DNS issues"

### DIFF
--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -28,7 +28,9 @@ jobs:
         run: yarn run semantic-release
       - name: Build Storybook
         run: yarn storybook:export
-      - name: Install Surge
-        run: npm install -g surge
-      - name: Deploy Storybook to Surge
-        run: surge ./storybook-static/ konveyor-lib-ui.surge.sh --token 62bd7a07b9bf812ff8d3ea91ccd2dc2f
+      - name: Deploy Storybook to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: storybook-static

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The React components in this library are compositions and extensions of [pattern
 
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
-Documentation and examples (Storybook): http://konveyor-lib-ui.surge.sh/
+Documentation and examples (Storybook): http://konveyor.github.io/lib-ui/
 
 ## Usage
 


### PR DESCRIPTION
Reverts konveyor/lib-ui#70

konveyor.github.io/lib-ui is no longer redirecting to konveyor.io, so I think if we want we could restore this to GitHub Pages instead of using Surge.