### PR TITLE
feat(useformstate): change `field.isValid` to ignore `isTouched`, add `shouldShowError` + `greenWhenValid`

### DIFF
--- a/src/components/ValidatedTextInput/ValidatedTextInput.tsx
+++ b/src/components/ValidatedTextInput/ValidatedTextInput.tsx
@@ -21,6 +21,8 @@ interface IValidatedTextInputProps
   field: IValidatedFormField<string> | IValidatedFormField<string | undefined>;
   /** Either a TextInput or TextArea from @patternfly/react-core. Defaults to TextInput */
   component?: typeof TextInput | typeof TextArea;
+  /** Whether to show the green 'valid' style when the field has been validated. Defaults to false ('default' style) */
+  greenWhenValid?: boolean;
   /** Any extra props for the PatternFly FormGroup */
   formGroupProps?: Partial<FormGroupProps>;
   /** Any extra props for the PatternFly TextInput or TextArea */
@@ -34,6 +36,7 @@ export const ValidatedTextInput: React.FunctionComponent<IValidatedTextInputProp
   fieldId,
   isRequired,
   type = 'text',
+  greenWhenValid = false,
   formGroupProps = {},
   inputProps = {},
 }: IValidatedTextInputProps) => (
@@ -41,20 +44,20 @@ export const ValidatedTextInput: React.FunctionComponent<IValidatedTextInputProp
     label={label}
     isRequired={isRequired}
     fieldId={fieldId}
-    {...getFormGroupProps(field as IValidatedFormField<string | undefined>)}
+    {...getFormGroupProps(field as IValidatedFormField<string | undefined>, greenWhenValid)}
     {...formGroupProps}
   >
     {component === TextInput ? (
       <TextInput
         id={fieldId}
         type={type}
-        {...getTextInputProps(field)}
+        {...getTextInputProps(field, greenWhenValid)}
         {...(inputProps as Partial<TextInputProps>)}
       />
     ) : (
       <TextArea
         id={fieldId}
-        {...getTextAreaProps(field)}
+        {...getTextAreaProps(field, greenWhenValid)}
         {...(inputProps as Partial<TextAreaProps>)}
         ref={null} // Necessary because of some weird TS issue with spreading Partial<TextAreaProps>['ref']
       />

--- a/src/hooks/useFormState/useFormState.stories.mdx
+++ b/src/hooks/useFormState/useFormState.stories.mdx
@@ -65,6 +65,7 @@ interface IFormField<T> {
 interface IValidatedFormField<T> extends IFormField<T> {
   error: yup.ValidationError | null;
   isValid: boolean;
+  shouldShowError: boolean; // True if field has validation errors and has been touched (false if it's just blank and untouched)
 }
 
 interface IFormState<TFieldValues> {

--- a/src/hooks/useFormState/useFormState.stories.tsx
+++ b/src/hooks/useFormState/useFormState.stories.tsx
@@ -29,7 +29,7 @@ export const BasicTextFields: React.FunctionComponent = () => {
           onChange={(event) => form.fields.name.setValue(event.target.value)}
           onBlur={() => form.fields.name.setIsTouched(true)}
         />
-        {!form.fields.name.isValid ? (
+        {form.fields.name.shouldShowError ? (
           <p style={{ color: 'red' }}>{form.fields.name.error?.message}</p>
         ) : null}
       </div>
@@ -42,7 +42,7 @@ export const BasicTextFields: React.FunctionComponent = () => {
           onChange={(event) => form.fields.description.setValue(event.target.value)}
           onBlur={() => form.fields.description.setIsTouched(true)}
         />
-        {!form.fields.description.isValid ? (
+        {form.fields.name.shouldShowError ? (
           <p style={{ color: 'red' }}>{form.fields.description.error?.message}</p>
         ) : null}
       </div>
@@ -71,7 +71,7 @@ export const PatternFlyTextFields: React.FunctionComponent = () => {
         label="Name"
         isRequired
         fieldId="example-2-name"
-        validated={form.fields.name.isValid ? 'default' : 'error'}
+        validated={form.fields.name.shouldShowError ? 'error' : 'default'}
         helperTextInvalid={form.fields.name.error?.message}
       >
         <TextInput
@@ -80,13 +80,13 @@ export const PatternFlyTextFields: React.FunctionComponent = () => {
           value={form.fields.name.value}
           onChange={form.fields.name.setValue}
           onBlur={() => form.fields.name.setIsTouched(true)}
-          validated={form.fields.name.isValid ? 'default' : 'error'}
+          validated={form.fields.name.shouldShowError ? 'error' : 'default'}
         />
       </FormGroup>
       <FormGroup
         label="Description"
         fieldId="example-2-desc"
-        validated={form.fields.description.isValid ? 'default' : 'error'}
+        validated={form.fields.description.shouldShowError ? 'error' : 'default'}
         helperTextInvalid={form.fields.description.error?.message}
       >
         <TextArea
@@ -94,7 +94,7 @@ export const PatternFlyTextFields: React.FunctionComponent = () => {
           value={form.fields.description.value}
           onChange={form.fields.description.setValue}
           onBlur={() => form.fields.description.setIsTouched(true)}
-          validated={form.fields.description.isValid ? 'default' : 'error'}
+          validated={form.fields.description.shouldShowError ? 'error' : 'default'}
         />
       </FormGroup>
       <Flex>
@@ -264,7 +264,7 @@ export const ComplexFieldTypes: React.FunctionComponent = () => {
             </option>
           ))}
         </select>
-        {!form.fields.store.isValid ? (
+        {form.fields.store.shouldShowError ? (
           <p style={{ color: 'red' }}>{form.fields.store.error?.message}</p>
         ) : null}
       </div>
@@ -286,7 +286,7 @@ export const ComplexFieldTypes: React.FunctionComponent = () => {
             <label htmlFor={`${item}-checkbox`}>{item}</label>
           </div>
         ))}
-        {!form.fields.items.isValid ? (
+        {form.fields.items.shouldShowError ? (
           <p style={{ color: 'red' }}>{form.fields.items.error?.message}</p>
         ) : null}
       </div>


### PR DESCRIPTION
Previously the field-level `isValid` property would be true on first render and only accurately reflect the validation after `isTouched` becomes true (the user blurred the field, in most cases). This is misleading and can lead to issues. `isValid` will now always accurately reflect the validation, so it will be false on first render if a required text field is blank. Consumers should now only show errors on a field if both `isValid` is false and `isTouched` is true. The new property `field.shouldShowError` has been added as a shorthand for this.

Also, a new parameter `greenWhenValid` has been added to `ValidatedTextInput` and the `get*Props` helpers. This is useful for fields with asynchronous validation that should show a green check when the field is valid, using the `validated="success"` prop for the PatternFly components.

BREAKING CHANGE: Forms that rely on `!field.isValid` to show errors will now show validation errors on all required fields as soon as the form first renders. Consumers should replace the `!field.isValid` condition with `field.shouldShowError` or `!field.isValid && field.isTouched`.

Resolves #82