### PR TITLE
feat(useformstate): add `markSaved` and other methods for manipulating multiple form fields at once

### DIFF
--- a/src/hooks/useFormState/useFormState.stories.mdx
+++ b/src/hooks/useFormState/useFormState.stories.mdx
@@ -52,11 +52,12 @@ interface IFormField<T> {
   setValue: React.Dispatch<React.SetStateAction<T>>;
   defaultValue: T;
   cleanValue: T;
-  reinitialize: (value: T) => void; // Sets defaultValue, cleanValue and value
-  prefill: (value: T) => void; // Sets cleanValue and value
-  clear: () => void; // Sets value to defaultValue
-  revert: () => void; // Sets value to cleanValue
-  isDirty: boolean; // True if value is different from cleanValue
+  reinitialize: (value: T) => void; // Sets defaultValue, cleanValue and current value. Value will be restored on revert or clear. Useful if initial values are loaded asynchronously.
+  prefill: (value: T) => void; // Sets cleanValue and current value. Value will be restored on revert but not clear. Useful if values to be edited are loaded asynchronously but retains separate defaultValue for clear.
+  markSaved: () => void; // Sets cleanValue to current value. Current value will be restored on revert but not clear. Useful if values have been saved to storage but the form is still open.
+  clear: () => void; // Sets current value to defaultValue.
+  revert: () => void; // Sets current value to cleanValue.
+  isDirty: boolean; // True if current value is different from cleanValue.
   isTouched: boolean;
   setIsTouched: (isTouched: boolean) => void;
   schema: yup.AnySchema<T>;
@@ -72,10 +73,14 @@ interface IFormState<TFieldValues> {
   fields: ValidatedFormFields<TFieldValues>;
   values: TFieldValues; // For convenience in submitting forms (values are also included in fields property)
   isDirty: boolean;
-  isValid: boolean;
   isTouched: boolean;
-  clear: () => void;
-  revert: () => void;
+  isValid: boolean;
+  setValues: (newValues: Partial<TFieldValues>) => void; // Sets multiple values at once.
+  reinitialize: (newValues: Partial<TFieldValues>) => void; // Reinitializes multiple values at once (see IFormField<T>)
+  prefill: (newValues: Partial<TFieldValues>) => void; // Prefills multiple values at once (see IFormField<T>)
+  markSaved: () => void; // Marks all fields as clean/saved (see IFormField<T>)
+  clear: () => void; // Clears all fields (see IFormField<T>)
+  revert: () => void; // Reverts all fields (see IFormField<T>)
 }
 ```
 


### PR DESCRIPTION
See updated comments on the prop interfaces. `markSaved` is useful to set all fields as clean
after saving form values to storage, so that revert() will restore those values.
Other new methods apply the existing field-level methods to multiple fields at once.

Needed for https://github.com/konveyor/crane-ui-plugin/pull/17