### PR TITLE
feat(ValidatedTextInput): default field label to label defined in schema if present

### DIFF
--- a/src/components/ValidatedTextInput/ValidatedTextInput.tsx
+++ b/src/components/ValidatedTextInput/ValidatedTextInput.tsx
@@ -32,7 +32,7 @@ interface IValidatedTextInputProps
 export const ValidatedTextInput: React.FunctionComponent<IValidatedTextInputProps> = ({
   field,
   component = TextInput,
-  label,
+  label = field.schema.describe().label,
   fieldId,
   isRequired,
   type = 'text',


### PR DESCRIPTION
If the yup schema of a text field contains a `.label()` (needed for good error messages), `ValidatedTextInput` will use it as a default for the `label` prop so the consumer doesn't have to duplicate it.