### PR TITLE
fix(ValidatedPasswordInput): default to label from field schema (match ValidatedTextInput behavior)

### DIFF
--- a/src/components/ValidatedTextInput/ValidatedPasswordInput.tsx
+++ b/src/components/ValidatedTextInput/ValidatedPasswordInput.tsx
@@ -28,7 +28,7 @@ interface IValidatedPasswordInputProps
 
 export const ValidatedPasswordInput: React.FunctionComponent<IValidatedPasswordInputProps> = ({
   field,
-  label,
+  label = field.schema.describe().label,
   fieldId,
   isRequired,
   greenWhenValid = false,


### PR DESCRIPTION
Replicate behavior of https://github.com/konveyor/lib-ui/pull/85 for ValidatedPasswordInput