### PR TITLE
feat(kube-client): allow arbitrary strings for the `kind` property on resources being queried

### DIFF
--- a/src/modules/kube-client/resources/core.ts
+++ b/src/modules/kube-client/resources/core.ts
@@ -2,13 +2,13 @@ import { NamespacedResource, ClusterResource, IGroupVersionKindPlural } from './
 
 export class CoreNamespacedResource extends NamespacedResource {
   private _gvk: IGroupVersionKindPlural;
-  constructor(kind: CoreNamespacedResourceKind, namespace: string) {
+  constructor(kindPlural: string, namespace: string) {
     super(namespace);
 
     this._gvk = {
       group: '',
       version: 'v1',
-      kindPlural: kind,
+      kindPlural,
     };
   }
   gvk(): IGroupVersionKindPlural {
@@ -27,11 +27,11 @@ export class CoreNamespacedResource extends NamespacedResource {
 export class ExtendedCoreNamespacedResource extends CoreNamespacedResource {
   private _operation: ExtendedCoreNamespacedResourceKind;
   constructor(
-    kind: CoreNamespacedResourceKind,
+    kindPlural: string,
     namespace: string,
     operation: ExtendedCoreNamespacedResourceKind
   ) {
-    super(kind, namespace);
+    super(kindPlural, namespace);
 
     this._operation = operation;
   }
@@ -47,13 +47,13 @@ export class ExtendedCoreNamespacedResource extends CoreNamespacedResource {
 
 export class CoreClusterResource extends ClusterResource {
   private _gvk: IGroupVersionKindPlural;
-  constructor(kind: CoreClusterResourceKind) {
+  constructor(kindPlural: string) {
     super();
 
     this._gvk = {
       group: '',
       version: 'v1',
-      kindPlural: kind,
+      kindPlural,
     };
   }
   gvk(): IGroupVersionKindPlural {


### PR DESCRIPTION
The kube-client module was originally abstracted out from mig-ui and still only directly supported the resource `kind`s needed by that UI.

In forklift-ui, we created our own `ForkliftResource` class to solve this problem, but that isn't really necessary when we're just trying to load core resources that aren't explicitly listed in the enums here, so we should just allow any string for the kind.

Needed for https://github.com/konveyor/crane-ui-plugin/pull/23