### PR TITLE
feat(hooks): Add useLocalStorage hook and documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "sass-loader": "^11.0.1",
     "semantic-release": "^19.0.3",
     "ts-jest": "^26.5.5",
-    "tslib": "^2.2.0",
+    "tslib": "^2.4.0",
     "typescript": "^4.2.4"
   },
   "config": {

--- a/src/hooks/useLocalStorage/index.ts
+++ b/src/hooks/useLocalStorage/index.ts
@@ -1,0 +1,1 @@
+export * from './useLocalStorage';

--- a/src/hooks/useLocalStorage/useLocalStorage.stories.mdx
+++ b/src/hooks/useLocalStorage/useLocalStorage.stories.mdx
@@ -46,8 +46,9 @@ If `setValue` is called with a value which cannot be serialized to JSON
 or if an error is thrown by the `localStorage` API, the error is caught and logged to the console and the `value` falls
 back to the `defaultValue`.
 
-`useLocalStorage` is safe to use in a unit testing environment where `window.localStorage` is not available.
-If `window` is undefined, the hook will simply always use the `defaultValue` and the setter function will do nothing.
+`useLocalStorage` is safe to use in a server-side rendering or unit testing environment where `window.localStorage` is
+not available. If `window` is undefined, the hook will simply always use the `defaultValue` and the setter function
+will do nothing.
 
 ## Examples
 

--- a/src/hooks/useLocalStorage/useLocalStorage.stories.mdx
+++ b/src/hooks/useLocalStorage/useLocalStorage.stories.mdx
@@ -1,9 +1,14 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
 import { useLocalStorage } from './useLocalStorage';
 import {
+  ClearAllExamplesButton,
+  PersistentCounterExample,
   PersistentTextFieldExample,
   PersistentCheckboxExample,
   WelcomeModalExample,
+  ReusedKeyExample,
+  CustomHookExample,
+  ComplexValueExample,
 } from './useLocalStorage.stories.tsx';
 import GithubLink from '../../../.storybook/helpers/GithubLink';
 
@@ -11,31 +16,60 @@ import GithubLink from '../../../.storybook/helpers/GithubLink';
 
 # useLocalStorage
 
-A custom hook resembling `React.useState` which persists the value using the browser's localStorage API.
+A custom hook resembling `React.useState` which persists and synchronizes any JSON-serializable value using the
+browser's [localStorage API](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage).
 
-Can be used as a drop-in replacement for `useState`, but the stored value must be a string.
+The value will persist across page reloads, and updates to the value will cause a re-render anywhere `useLocalStorage`
+is called with the same unique `key` string. The value identified by a `key` will stay in sync between multiple calls
+within the same page, across multiple pages and across multiple tabs/windows via a `StorageEvent` listener. The value
+will only be lost if the user switches to a different browser or a fresh incognito session, or if they clear their
+browsing data.
 
+Just like `useState`, `useLocalStorage` returns the current value and setter function in an array tuple so they can be
+given arbitrary names using [destructuring assignment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment),
+and it supports TypeScript [generics](https://www.typescriptlang.org/docs/handbook/generics.html) and can optionally
+infer its return types based on the `defaultValue`.
+
+```ts
+const [value, setValue] = useLocalStorage<T>(key: string, defaultValue: T);
 ```
-TODO: put type signature here
-```
 
-## Using default values
+## Notes
 
-TODO
+On first render, `value` will either be synchronously loaded from storage or will fall back to `defaultValue` if there
+is no value in storage. If necessary, the storage value can be fully removed by calling `setValue(undefined)`, which
+will re-render with `value` set back to `defaultValue`. Note that this is distinct from calling `setValue(null)`, which
+will persist and synchronize the `null` value.
 
-## Using boolean values
+If `setValue` is called with a value which cannot be serialized to JSON
+([see Exceptions here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#exceptions)),
+or if an error is thrown by the `localStorage` API, the error is caught and logged to the console and the `value` falls
+back to the `defaultValue`.
 
-TODO
+`useLocalStorage` is safe to use in a unit testing environment where `window.localStorage` is not available.
+If `window` is undefined, the hook will simply always use the `defaultValue` and the setter function will do nothing.
 
 ## Examples
 
-### Persistent text field
+For each of these examples, try opening this page in multiple windows side-by-side to see the synchronization in action,
+and try reloading the page to see the persistence in action.
+
+### Persistent counter (`number` value)
+
+The classic `useState` example, but persistent. The `count` variable's type here is inferred as a primitive `number`,
+not a `string`.
+
+<Canvas>
+  <Story story={PersistentCounterExample} />
+</Canvas>
+
+### Persistent text field (`string` value)
 
 <Canvas>
   <Story story={PersistentTextFieldExample} />
 </Canvas>
 
-### Persistent checkbox
+### Persistent checkbox (`boolean` value)
 
 <Canvas>
   <Story story={PersistentCheckboxExample} />
@@ -43,6 +77,40 @@ TODO
 
 ### Modal with "Don't show this again" checkbox
 
+This button will simulate navigating to a page that has a welcome modal which can be disabled for future visits by the user.
+
 <Canvas>
   <Story story={WelcomeModalExample} />
 </Canvas>
+
+### Sharing a persistent value by reusing the same `key`
+
+The same value can be rendered and updated in multiple different components and in the same component rendered in multiple places
+by reusing the same unique `key` string. In this implementation, you will need to use the same `defaultValue` for each instance
+or you'll end up with the values out of sync until one of them is changed by the user. See the next example for an improvement.
+
+<Canvas>
+  <Story story={ReusedKeyExample} />
+</Canvas>
+
+### Sharing a persistent value by factoring out into a custom hook
+
+Sharing the same value can be done more easily (and without the repeated `defaultValue` problem) by creating a custom hook
+wrapping your `useLocalStorage` call and using the custom hook in multiple places.
+
+<Canvas>
+  <Story story={CustomHookExample} />
+</Canvas>
+
+### Persistent array and object values
+
+Any JSON-serializable value can be used with `useLocalStorage` such as an array or an object. Note that this may not be
+desirable; if possible it is simpler to use multiple instances of `useLocalStorage` with separate keys and individual primitive values.
+
+<Canvas>
+  <Story story={ComplexValueExample} />
+</Canvas>
+
+<ClearAllExamplesButton />
+
+<GithubLink path="src/hooks/useLocalStorage/useLocalStorage.ts" />

--- a/src/hooks/useLocalStorage/useLocalStorage.stories.mdx
+++ b/src/hooks/useLocalStorage/useLocalStorage.stories.mdx
@@ -1,0 +1,48 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
+import { useLocalStorage } from './useLocalStorage';
+import {
+  PersistentTextFieldExample,
+  PersistentCheckboxExample,
+  WelcomeModalExample,
+} from './useLocalStorage.stories.tsx';
+import GithubLink from '../../../.storybook/helpers/GithubLink';
+
+<Meta title="Hooks/useLocalStorage" component={useLocalStorage} />
+
+# useLocalStorage
+
+A custom hook resembling `React.useState` which persists the value using the browser's localStorage API.
+
+Can be used as a drop-in replacement for `useState`, but the stored value must be a string.
+
+```
+TODO: put type signature here
+```
+
+## Using default values
+
+TODO
+
+## Using boolean values
+
+TODO
+
+## Examples
+
+### Persistent text field
+
+<Canvas>
+  <Story story={PersistentTextFieldExample} />
+</Canvas>
+
+### Persistent checkbox
+
+<Canvas>
+  <Story story={PersistentCheckboxExample} />
+</Canvas>
+
+### Modal with "Don't show this again" checkbox
+
+<Canvas>
+  <Story story={WelcomeModalExample} />
+</Canvas>

--- a/src/hooks/useLocalStorage/useLocalStorage.stories.mdx
+++ b/src/hooks/useLocalStorage/useLocalStorage.stories.mdx
@@ -37,9 +37,9 @@ const [value, setValue] = useLocalStorage<T>(key: string, defaultValue: T);
 ## Notes
 
 On first render, `value` will either be synchronously loaded from storage or will fall back to `defaultValue` if there
-is no value in storage. If necessary, the storage value can be fully removed by calling `setValue(undefined)`, which
-will re-render with `value` set back to `defaultValue`. Note that this is distinct from calling `setValue(null)`, which
-will persist and synchronize the `null` value.
+is no value in storage. If necessary, the data can be fully removed from `localStorage` by calling
+`setValue(undefined)`, which will re-render with `value` set back to `defaultValue`. Note that this is distinct from
+calling `setValue(null)`, which will persist and synchronize the `null` value.
 
 If `setValue` is called with a value which cannot be serialized to JSON
 ([see Exceptions here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#exceptions)),

--- a/src/hooks/useLocalStorage/useLocalStorage.stories.mdx
+++ b/src/hooks/useLocalStorage/useLocalStorage.stories.mdx
@@ -48,7 +48,7 @@ back to the `defaultValue`.
 
 `useLocalStorage` is safe to use in a server-side rendering or unit testing environment where `window.localStorage` is
 not available. If `window` is undefined, the hook will simply always use the `defaultValue` and the setter function
-will do nothing.
+will only update the cached value in React state.
 
 ## Examples
 

--- a/src/hooks/useLocalStorage/useLocalStorage.stories.tsx
+++ b/src/hooks/useLocalStorage/useLocalStorage.stories.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react';
+import { Button, Checkbox, TextContent, Text, TextInput, Modal } from '@patternfly/react-core';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import { useLocalStorage } from './useLocalStorage';
+
+export const PersistentTextFieldExample: React.FunctionComponent = () => {
+  const [value, setValue] = useLocalStorage('exampleTextFieldValue');
+  return <TextInput id="text-field-example" value={value || ''} onChange={setValue} />;
+};
+
+export const PersistentCheckboxExample: React.FunctionComponent = () => {
+  const [isCheckedStr, setIsCheckedStr] = useLocalStorage('exampleCheckboxChecked');
+  return (
+    <Checkbox
+      id="checkbox-example"
+      label="This checkbox will persist across multiple tabs and page reloads!"
+      isChecked={isCheckedStr === 'true'}
+      onChange={(checked) => setIsCheckedStr(checked ? 'true' : 'false')}
+    />
+  );
+};
+
+export const WelcomeModalExample: React.FunctionComponent = () => {
+  const ExamplePage: React.FunctionComponent = () => {
+    const [isModalDisabledStr, setIsModalDisabledStr] = useLocalStorage('welcomeModalDisabled');
+    const [isWelcomeModalOpen, setIsModalOpen] = React.useState(isModalDisabledStr !== 'true');
+
+    return (
+      <>
+        <TextContent>
+          <Text component="h4">Some Page Title</Text>
+          <Text component="p">You reached the example page!</Text>
+          <Text component="p">
+            If you checked the &quot;don&apos;t show this again&quot; box, try reloading the page
+            and you&apos;ll see the welcome modal won&apos;t come back. If you want to see it again,
+            clear your browsing data or try an incognito tab.
+          </Text>
+          <Button onClick={() => setIsExamplePageOpen(false)}>Go back</Button>
+        </TextContent>
+        <Modal
+          isOpen={isWelcomeModalOpen}
+          title="Welcome to the example!"
+          onClose={() => setIsModalOpen(false)}
+        >
+          <TextContent>
+            <Text component="p">
+              This is an introductory message that you will see each time you visit the example
+              page, unless you check the box below!
+            </Text>
+          </TextContent>
+          <Checkbox
+            className={spacing.mtMd}
+            label="Don't show this again"
+            id="show-again-checkbox"
+            isChecked={isModalDisabledStr === 'true'}
+            onChange={(checked: boolean) => {
+              setIsModalDisabledStr(checked ? 'true' : 'false');
+            }}
+          />
+        </Modal>
+      </>
+    );
+  };
+
+  // The following is just for the embedded example to work. In a real app you'd just follow the above ExamplePage.
+  const [isExamplePageOpen, setIsExamplePageOpen] = React.useState(false);
+  if (!isExamplePageOpen) {
+    return (
+      <>
+        <TextContent>
+          <Text component="p">This button will take you to a page that has a welcome modal!</Text>
+        </TextContent>
+        <Button variant="primary" onClick={() => setIsExamplePageOpen(true)}>
+          Navigate to example page
+        </Button>
+      </>
+    );
+  }
+  return <ExamplePage />;
+};

--- a/src/hooks/useLocalStorage/useLocalStorage.stories.tsx
+++ b/src/hooks/useLocalStorage/useLocalStorage.stories.tsx
@@ -1,61 +1,101 @@
 import * as React from 'react';
-import { Button, Checkbox, TextContent, Text, TextInput, Modal } from '@patternfly/react-core';
+import * as yup from 'yup';
+import {
+  Button,
+  Checkbox,
+  TextContent,
+  Text,
+  TextInput,
+  Modal,
+  NumberInput,
+  List,
+  ListItem,
+  Form,
+  FormGroup,
+} from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { useLocalStorage } from './useLocalStorage';
+import { useFormState, useFormField } from '../useFormState';
+import { ValidatedTextInput } from '../../components/ValidatedTextInput';
+import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
+
+export const PersistentCounterExample: React.FunctionComponent = () => {
+  const [count, setCount] = useLocalStorage('exampleCounter', 0);
+  return (
+    <NumberInput
+      value={count}
+      onMinus={() => setCount(count - 1)}
+      onPlus={() => setCount(count + 1)}
+      onChange={(event) => setCount(Number(event.currentTarget.value))}
+      inputName="input"
+      inputAriaLabel="number input"
+      minusBtnAriaLabel="minus"
+      plusBtnAriaLabel="plus"
+    />
+  );
+};
 
 export const PersistentTextFieldExample: React.FunctionComponent = () => {
-  const [value, setValue] = useLocalStorage('exampleTextFieldValue');
-  return <TextInput id="text-field-example" value={value || ''} onChange={setValue} />;
+  const [value, setValue] = useLocalStorage('exampleTextField', '');
+  return (
+    <TextInput aria-label="Persistent text field example input" value={value} onChange={setValue} />
+  );
 };
 
 export const PersistentCheckboxExample: React.FunctionComponent = () => {
-  const [isCheckedStr, setIsCheckedStr] = useLocalStorage('exampleCheckboxChecked');
+  const [isChecked, setIsChecked] = useLocalStorage('exampleCheckboxChecked', false);
   return (
     <Checkbox
       id="checkbox-example"
-      label="This checkbox will persist across multiple tabs and page reloads!"
-      isChecked={isCheckedStr === 'true'}
-      onChange={(checked) => setIsCheckedStr(checked ? 'true' : 'false')}
+      label="I'm a persistent checkbox!"
+      isChecked={isChecked}
+      onChange={setIsChecked}
     />
   );
 };
 
 export const WelcomeModalExample: React.FunctionComponent = () => {
   const ExamplePage: React.FunctionComponent = () => {
-    const [isModalDisabledStr, setIsModalDisabledStr] = useLocalStorage('welcomeModalDisabled');
-    const [isWelcomeModalOpen, setIsModalOpen] = React.useState(isModalDisabledStr !== 'true');
-
+    const [isModalDisabled, setIsModalDisabled] = useLocalStorage('welcomeModalDisabled', false);
+    const [isModalOpen, setIsModalOpen] = React.useState(!isModalDisabled);
     return (
       <>
         <TextContent>
-          <Text component="h4">Some Page Title</Text>
+          <Text component="h4">Example Page Title</Text>
           <Text component="p">You reached the example page!</Text>
           <Text component="p">
             If you checked the &quot;don&apos;t show this again&quot; box, try reloading the page
-            and you&apos;ll see the welcome modal won&apos;t come back. If you want to see it again,
-            clear your browsing data or try an incognito tab.
+            and returning here and you&apos;ll see the welcome modal won&apos;t come back. If you
+            want to see it again, clear your browsing data or try an incognito tab, or use the
+            &quot;Clear localStorage for all examples&quot; button above.
           </Text>
-          <Button onClick={() => setIsExamplePageOpen(false)}>Go back</Button>
+          <Button variant="secondary" onClick={() => setIsExamplePageOpen(false)}>
+            Go back
+          </Button>
         </TextContent>
         <Modal
-          isOpen={isWelcomeModalOpen}
-          title="Welcome to the example!"
+          variant="small"
+          isOpen={isModalOpen}
+          title="Welcome to Example Page!"
           onClose={() => setIsModalOpen(false)}
+          actions={[
+            <Button key="confirm" variant="primary" onClick={() => setIsModalOpen(false)}>
+              Get started
+            </Button>,
+          ]}
         >
-          <TextContent>
+          <TextContent className={spacing.mbMd}>
             <Text component="p">
               This is an introductory message that you will see each time you visit the example
-              page, unless you check the box below!
+              page, unless you check the box below! Tell your users what this page is all about, but
+              let them choose not to be annoyed with it every time.
             </Text>
           </TextContent>
           <Checkbox
-            className={spacing.mtMd}
             label="Don't show this again"
             id="show-again-checkbox"
-            isChecked={isModalDisabledStr === 'true'}
-            onChange={(checked: boolean) => {
-              setIsModalDisabledStr(checked ? 'true' : 'false');
-            }}
+            isChecked={isModalDisabled}
+            onChange={setIsModalDisabled}
           />
         </Modal>
       </>
@@ -66,15 +106,166 @@ export const WelcomeModalExample: React.FunctionComponent = () => {
   const [isExamplePageOpen, setIsExamplePageOpen] = React.useState(false);
   if (!isExamplePageOpen) {
     return (
-      <>
-        <TextContent>
-          <Text component="p">This button will take you to a page that has a welcome modal!</Text>
-        </TextContent>
-        <Button variant="primary" onClick={() => setIsExamplePageOpen(true)}>
-          Navigate to example page
-        </Button>
-      </>
+      <Button variant="primary" onClick={() => setIsExamplePageOpen(true)}>
+        Navigate to example page
+      </Button>
     );
   }
   return <ExamplePage />;
 };
+
+export const ReusedKeyExample: React.FunctionComponent = () => {
+  // In a real app each of these components would be in separate files.
+  const ComponentA: React.FunctionComponent = () => {
+    const [value, setValue] = useLocalStorage('exampleReusedKey', 'default value here');
+    return (
+      <div className={spacing.mbLg}>
+        <TextContent className={spacing.mbSm}>
+          <Text component="h4">Component A</Text>
+        </TextContent>
+        <TextInput aria-label="Component A example text input" value={value} onChange={setValue} />
+      </div>
+    );
+  };
+  const ComponentB: React.FunctionComponent = () => {
+    const [value] = useLocalStorage('exampleReusedKey', 'default value here');
+    return (
+      <div className={spacing.mbLg}>
+        <TextContent className={spacing.mbSm}>
+          <Text component="h4">Component B</Text>
+          <Text component="p">{value}</Text>
+        </TextContent>
+      </div>
+    );
+  };
+  return (
+    <>
+      <ComponentA />
+      <ComponentA />
+      <ComponentB />
+    </>
+  );
+};
+
+export const CustomHookExample: React.FunctionComponent = () => {
+  // This could be exported from its own file and imported in multiple component files.
+  const useMyStoredValue = () => useLocalStorage('myStoredValue', 'default defined once');
+
+  // In a real app each of these components would be in separate files.
+  const ComponentA: React.FunctionComponent = () => {
+    const [value, setValue] = useMyStoredValue();
+    return (
+      <div className={spacing.mbLg}>
+        <TextContent className={spacing.mbSm}>
+          <Text component="h4">Component A</Text>
+        </TextContent>
+        <TextInput aria-label="Component A example text input" value={value} onChange={setValue} />
+      </div>
+    );
+  };
+  const ComponentB: React.FunctionComponent = () => {
+    const [value] = useLocalStorage('exampleReusedKey', 'default value here');
+    return (
+      <div className={spacing.mbLg}>
+        <TextContent className={spacing.mbSm}>
+          <Text component="h4">Component B</Text>
+          <Text component="p">{value}</Text>
+        </TextContent>
+      </div>
+    );
+  };
+  return (
+    <>
+      <ComponentA />
+      <ComponentA />
+      <ComponentB />
+    </>
+  );
+};
+
+export const ComplexValueExample: React.FunctionComponent = () => {
+  type Item = { name: string; description?: string };
+  const [items, setItems] = useLocalStorage<Item[]>('exampleArray', []);
+
+  const addForm = useFormState({
+    name: useFormField('', yup.string().required().label('Name')),
+    description: useFormField('', yup.string().label('Description')),
+  });
+
+  return (
+    <>
+      <TextContent className={spacing.mbLg}>
+        <Text component="h4">Saved items</Text>
+        {items.length > 0 ? (
+          <List>
+            {items.map((item, index) => (
+              <ListItem key={`${index}-${item.name}`}>
+                Name: {item.name}
+                {item.description ? <>, Description: {item.description}</> : null}
+                <Button
+                  variant="plain"
+                  aria-label="Remove"
+                  onClick={() =>
+                    setItems((value) => {
+                      const newArray = [...value];
+                      newArray.splice(index, 1);
+                      return newArray;
+                    })
+                  }
+                >
+                  <TimesIcon />
+                </Button>
+              </ListItem>
+            ))}
+          </List>
+        ) : (
+          <Text component="p">No items yet</Text>
+        )}
+      </TextContent>
+      <TextContent className={spacing.mbMd}>
+        <Text component="h4">Add item:</Text>
+      </TextContent>
+      <Form isWidthLimited isHorizontal className={spacing.mbMd}>
+        <ValidatedTextInput isRequired fieldId="name" field={addForm.fields.name} />
+        <ValidatedTextInput fieldId="description" field={addForm.fields.description} />
+        <FormGroup fieldId="submit">
+          <Button
+            id="submit"
+            onClick={() => {
+              const { name, description } = addForm.values;
+              setItems((value) => [...value, { name, description }]);
+            }}
+          >
+            Add
+          </Button>
+        </FormGroup>
+      </Form>
+    </>
+  );
+};
+
+export const ClearAllExamplesButton: React.FunctionComponent = () => (
+  <div className={spacing.myXl}>
+    <Button
+      variant="secondary"
+      isInline
+      onClick={() => {
+        const allKeys = [
+          'exampleCounter',
+          'exampleTextField',
+          'exampleCheckboxChecked',
+          'welcomeModalDisabled',
+          'exampleReusedKey',
+          'myStoredValue',
+          'exampleArray',
+        ];
+        allKeys.forEach((key) => {
+          window.localStorage.removeItem(key);
+          window.dispatchEvent(new StorageEvent('storage', { key, newValue: null }));
+        });
+      }}
+    >
+      Clear localStorage for all examples
+    </Button>
+  </div>
+);

--- a/src/hooks/useLocalStorage/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage/useLocalStorage.ts
@@ -11,7 +11,7 @@ const getValueFromStorage = <T>(key: string, defaultValue: T): T => {
   }
 };
 
-const setValueInStorage = <T>(key: string, newValue: T) => {
+const setValueInStorage = <T>(key: string, newValue: T | undefined) => {
   if (typeof window === 'undefined') return;
   try {
     if (newValue !== undefined) {

--- a/src/hooks/useLocalStorage/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage/useLocalStorage.ts
@@ -3,8 +3,8 @@ import * as React from 'react';
 const getValueFromStorage = <T>(key: string, defaultValue: T): T => {
   if (typeof window === 'undefined') return defaultValue;
   try {
-    const item = window.localStorage.getItem(key);
-    return item ? (JSON.parse(item) as T) : defaultValue;
+    const itemJSON = window.localStorage.getItem(key);
+    return itemJSON ? (JSON.parse(itemJSON) as T) : defaultValue;
   } catch (error) {
     console.error(error);
     return defaultValue;

--- a/src/hooks/useLocalStorage/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage/useLocalStorage.ts
@@ -1,0 +1,26 @@
+import * as React from 'react';
+
+export const useLocalStorage = (key: string): [string | null, (value: string | null) => void] => {
+  const [value, setCachedValue] = React.useState<string | null>(window.localStorage.getItem(key));
+
+  const setValue = (newValue: string | null) => {
+    if (newValue === null) {
+      window.localStorage.removeItem(key);
+    } else {
+      window.localStorage.setItem(key, newValue);
+    }
+    window.dispatchEvent(new StorageEvent('storage', { key, newValue }));
+  };
+
+  React.useEffect(() => {
+    const onStorageUpdated = (event: StorageEvent) => {
+      if (event.key === key) setCachedValue(event.newValue);
+    };
+    window.addEventListener('storage', onStorageUpdated);
+    return () => {
+      window.removeEventListener('storage', onStorageUpdated);
+    };
+  }, [key]);
+
+  return [value, setValue];
+};

--- a/src/hooks/useLocalStorage/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage/useLocalStorage.ts
@@ -1,26 +1,63 @@
 import * as React from 'react';
 
-export const useLocalStorage = (key: string): [string | null, (value: string | null) => void] => {
-  const [value, setCachedValue] = React.useState<string | null>(window.localStorage.getItem(key));
+const getValueFromStorage = <T>(key: string, defaultValue: T): T => {
+  if (typeof window === 'undefined') return defaultValue;
+  try {
+    const item = window.localStorage.getItem(key);
+    return item ? (JSON.parse(item) as T) : defaultValue;
+  } catch (error) {
+    console.error(error);
+    return defaultValue;
+  }
+};
 
-  const setValue = (newValue: string | null) => {
-    if (newValue === null) {
-      window.localStorage.removeItem(key);
+const setValueInStorage = <T>(key: string, newValue: T) => {
+  if (typeof window === 'undefined') return;
+  try {
+    if (newValue !== undefined) {
+      const newValueJSON = JSON.stringify(newValue);
+      window.localStorage.setItem(key, newValueJSON);
+      // setItem only causes the StorageEvent to be dispatched in other windows. We dispatch it here
+      // manually so that all instances of useLocalStorage on this window also react to this change.
+      window.dispatchEvent(new StorageEvent('storage', { key, newValue: newValueJSON }));
     } else {
-      window.localStorage.setItem(key, newValue);
+      window.localStorage.removeItem(key);
+      window.dispatchEvent(new StorageEvent('storage', { key, newValue: null }));
     }
-    window.dispatchEvent(new StorageEvent('storage', { key, newValue }));
-  };
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export const useLocalStorage = <T>(
+  key: string,
+  defaultValue: T
+): [T, React.Dispatch<React.SetStateAction<T>>] => {
+  const [cachedValue, setCachedValue] = React.useState<T>(getValueFromStorage(key, defaultValue));
+
+  const setValue: React.Dispatch<React.SetStateAction<T>> = React.useCallback(
+    (newValueOrFn: T | ((prevState: T) => T)) => {
+      const newValue =
+        newValueOrFn instanceof Function
+          ? newValueOrFn(getValueFromStorage(key, defaultValue))
+          : newValueOrFn;
+      setValueInStorage(key, newValue);
+    },
+    [key, defaultValue]
+  );
 
   React.useEffect(() => {
+    if (typeof window === 'undefined') return;
     const onStorageUpdated = (event: StorageEvent) => {
-      if (event.key === key) setCachedValue(event.newValue);
+      if (event.key === key) {
+        setCachedValue(event.newValue ? JSON.parse(event.newValue) : defaultValue);
+      }
     };
     window.addEventListener('storage', onStorageUpdated);
     return () => {
       window.removeEventListener('storage', onStorageUpdated);
     };
-  }, [key]);
+  }, [key, defaultValue]);
 
-  return [value, setValue];
+  return [cachedValue, setValue];
 };

--- a/src/hooks/useLocalStorage/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage/useLocalStorage.ts
@@ -42,6 +42,10 @@ export const useLocalStorage = <T>(
           ? newValueOrFn(getValueFromStorage(key, defaultValue))
           : newValueOrFn;
       setValueInStorage(key, newValue);
+      if (typeof window === 'undefined') {
+        // If we're in a server or test environment, the cache won't update automatically since there's no StorageEvent.
+        setCachedValue(newValue);
+      }
     },
     [key, defaultValue]
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,5 +5,6 @@ export * from './components/LoadingEmptyState';
 
 export * from './hooks/useSelectionState';
 export * from './hooks/useFormState';
+export * from './hooks/useLocalStorage';
 
 export * from './modules/kube-client';

--- a/yarn.lock
+++ b/yarn.lock
@@ -14913,7 +14913,7 @@ tslib@^2.0.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
   integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
 
-tslib@^2.0.1, tslib@^2.2.0:
+tslib@^2.0.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
   integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==


### PR DESCRIPTION
This PR adds the `useLocalStorage` hook, based on [the implementation in crane-ui-plugin here](https://github.com/konveyor/crane-ui-plugin/blob/main/src/common/hooks/useLocalStorage.ts), which is itself a simplification of the `LocalStorageContext` from forklift-ui [here](https://github.com/konveyor/forklift-ui/blob/main/pkg/web/src/app/common/context/LocalStorageContext.tsx).

It has been enhanced since the crane-ui-plugin version to use `JSON.stringify()` and TypeScript generics so that any JSON-serializable value can be persistent instead of just strings. It also has error handling added and the addition of a check for `window` to be defined so that it won't break components in a server-rendering or unit testing environment.

I also upgraded `tslib` as part of this PR so we can use `[...spread]` syntax in examples.