### PR TITLE
feat(index): Add warnings about moving package to `@migtools/lib-ui`

### DIFF
--- a/.storybook/helpers/PackageMovedAlert.tsx
+++ b/.storybook/helpers/PackageMovedAlert.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { Alert, AlertActionLink } from '@patternfly/react-core';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+
+const navTo = (href: string) => window.top && (window.top.location.href = href);
+
+const PackageMovedAlert: React.FunctionComponent = () => (
+  <Alert
+    variant="danger"
+    title={<>IMPORTANT: This library has moved!</>}
+    isInline
+    className={spacing.mbLg}
+    actionLinks={
+      <>
+        <AlertActionLink onClick={() => navTo('https://www.npmjs.com/package/@migtools/lib-ui')}>
+          View new package on npm
+        </AlertActionLink>
+        <AlertActionLink onClick={() => navTo('https://github.com/migtools/lib-ui')}>
+          View new package on GitHub
+        </AlertActionLink>
+        <AlertActionLink onClick={() => navTo('https://migtools.github.io/lib-ui/')}>
+          View new documentation
+        </AlertActionLink>
+      </>
+    }
+  >
+    The <code>@konveyor/lib-ui</code> package is deprecated and has been moved to{' '}
+    <a href="https://www.npmjs.com/package/@migtools/lib-ui">
+      <code>@migtools/lib-ui</code>
+    </a>
+    . You must switch to that package for future upgrades. The version documented here is the final
+    release under the <code>@konveyor/lib-ui</code> name and is identical to the first release of{' '}
+    <code>@migtools/lib-ui</code>.{' '}
+  </Alert>
+);
+
+export default PackageMovedAlert;

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # @konveyor/lib-ui
 
+---
+
+# IMPORTANT: The `@konveyor/lib-ui` npm package is deprecated and has moved to `@migtools/lib-ui`.
+
+---
+
 Reusable React components, hooks, and TypeScript modules shared between Konveyor UI projects.
 
 This library exists as a place to store and reuse abstractions that are useful for multiple Konveyor UI projects, and are either not available in PatternFly yet or not covered by PatternFly's scope.

--- a/src/common/packageMovedConsoleWarning.ts
+++ b/src/common/packageMovedConsoleWarning.ts
@@ -1,0 +1,8 @@
+export const packageMovedConsoleWarning = `
+IMPORTANT: The @konveyor/lib-ui package is deprecated and has been moved to @migtools/lib-ui. You must switch to that package for future upgrades.
+The version you are using is the final release under the @konveyor/lib-ui name and is identical to the first release of @migtools/lib-ui.
+
+New package on npm: https://www.npmjs.com/package/@migtools/lib-ui
+New package on GitHub: https://github.com/migtools/lib-ui
+New documentation: https://migtools.github.io/lib-ui/
+`;

--- a/src/components/StatusIcon/StatusIcon.stories.mdx
+++ b/src/components/StatusIcon/StatusIcon.stories.mdx
@@ -1,8 +1,11 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
 import { StatusIcon } from './StatusIcon';
 import GithubLink from '../../../.storybook/helpers/GithubLink';
+import PackageMovedAlert from '../../../.storybook/helpers/PackageMovedAlert';
 
 <Meta title="Components/StatusIcon" component={StatusIcon} />
+
+<PackageMovedAlert />
 
 # StatusIcon
 

--- a/src/components/ValidatedTextInput/ValidatedTextInput.stories.mdx
+++ b/src/components/ValidatedTextInput/ValidatedTextInput.stories.mdx
@@ -2,8 +2,11 @@ import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
 import { ValidatedTextInput } from './ValidatedTextInput';
 import { PatternFlyTextFields } from './ValidatedTextInput.stories.tsx';
 import GithubLink from '../../../.storybook/helpers/GithubLink';
+import PackageMovedAlert from '../../../.storybook/helpers/PackageMovedAlert';
 
 <Meta title="Components/ValidatedTextInput" component={ValidatedTextInput} />
+
+<PackageMovedAlert />
 
 # ValidatedTextInput
 

--- a/src/hooks/useFormState/useFormState.stories.mdx
+++ b/src/hooks/useFormState/useFormState.stories.mdx
@@ -8,8 +8,11 @@ import {
   ComplexFieldTypes,
 } from './useFormState.stories.tsx';
 import GithubLink from '../../../.storybook/helpers/GithubLink';
+import PackageMovedAlert from '../../../.storybook/helpers/PackageMovedAlert';
 
 <Meta title="Hooks/useFormState" component={useFormState} />
+
+<PackageMovedAlert />
 
 # useFormState
 

--- a/src/hooks/useLocalStorage/useLocalStorage.stories.mdx
+++ b/src/hooks/useLocalStorage/useLocalStorage.stories.mdx
@@ -11,8 +11,11 @@ import {
   ComplexValueExample,
 } from './useLocalStorage.stories.tsx';
 import GithubLink from '../../../.storybook/helpers/GithubLink';
+import PackageMovedAlert from '../../../.storybook/helpers/PackageMovedAlert';
 
 <Meta title="Hooks/useLocalStorage" component={useLocalStorage} />
+
+<PackageMovedAlert />
 
 # useLocalStorage
 

--- a/src/hooks/useSelectionState/useSelectionState.stories.mdx
+++ b/src/hooks/useSelectionState/useSelectionState.stories.mdx
@@ -2,8 +2,11 @@ import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
 import { useSelectionState } from './useSelectionState';
 import { Checkboxes, ExpandableTable, ExternalState } from './useSelectionState.stories.tsx';
 import GithubLink from '../../../.storybook/helpers/GithubLink';
+import PackageMovedAlert from '../../../.storybook/helpers/PackageMovedAlert';
 
 <Meta title="Hooks/useSelectionState" component={useSelectionState} />
+
+<PackageMovedAlert />
 
 # useSelectionState
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import { packageMovedConsoleWarning } from './common/packageMovedConsoleWarning';
+
 export * from './components/StatusIcon';
 export * from './components/ValidatedTextInput';
 export * from './components/ResolvedQuery';
@@ -8,3 +10,5 @@ export * from './hooks/useFormState';
 export * from './hooks/useLocalStorage';
 
 export * from './modules/kube-client';
+
+console.warn(packageMovedConsoleWarning);

--- a/src/modules/kube-client/index.ts
+++ b/src/modules/kube-client/index.ts
@@ -1,4 +1,8 @@
+import { packageMovedConsoleWarning } from '../../common/packageMovedConsoleWarning';
+
 export * from './client';
 export * from './client_factory';
 export * from './resources/common';
 export * from './resources/core';
+
+console.warn(packageMovedConsoleWarning);


### PR DESCRIPTION
Adds console warnings and an Alert at the top of every Storybook docs page regarding the move to the `@migtools/lib-ui` package name.

In the console:
![Screen Shot 2022-08-23 at 12 35 19 PM](https://user-images.githubusercontent.com/811963/186213813-aeee5d3c-96f6-4b18-b1a4-9794e06326d5.png)

In Storybook:
![Screen Shot 2022-08-23 at 12 21 25 PM](https://user-images.githubusercontent.com/811963/186213856-5d3c0d8b-8586-446c-82e5-3f0559f86e0a.png)

